### PR TITLE
Refactor map-view

### DIFF
--- a/src/map-view.html
+++ b/src/map-view.html
@@ -1,8 +1,8 @@
 <link rel="import" href="../bower_components/polymer/polymer.html">
 <link rel="import" href="../bower_components/paper-button/paper-button.html">
-<link rel="import" href="../bower_components/paper-checkbox/paper-checkbox.html">
 <link rel="import" href="../bower_components/paper-styles/typography.html">
 <link rel="import" href="../bower_components/google-map/google-map.html">
+<link rel="import" href="proximity-checkbox.html">
 
 <link rel="import" href="shared-styles.html">
 
@@ -18,20 +18,23 @@
     </style>
     <div class="content">
       <google-map zoom = "17" latitude="[[latitude]]" longitude="[[longitude]]" api-key="AIzaSyDwMK5MooS-bAAEdTq74fgxcc_GVQpd7TM" fit-to-markers>
-        <google-map-marker latitude="40.137244" longitude="-85.284714"></google-map-marker>
-        <google-map-marker latitude="40.135326" longitude="-85.278264"></google-map-marker>
-        <google-map-marker latitude="40.132397" longitude="-85.279364"></google-map-marker>
+        <template is="dom-repeat" items="[[locations]]" item="item">
+          <google-map-marker latitude="[[item.latitude]]" longitude="[[item.longitude]]">
+          </google-map-marker>
+        </template>
       </google-map>
       <paper-button raised on-tap="_useCurrentLocation">Use Current Location</paper-button>
     </div>
 
     <br>
     <h1>This is a checkbox demo.</h1>
-    <paper-checkbox>Reservoir Campgrounds</paper-checkbox>
-    <br>
-    <paper-checkbox>Prarie View Restaurant and Pub</paper-checkbox>
-    <br>
-    <paper-checkbox>Dry Dock Marina</paper-checkbox>
+    <template is="dom-repeat" items="[[locations]]" item="item">
+      <proximity-checkbox
+        marker-latitude="[[item.latitude]]" marker-longitude="[[item.longitude]]"
+        current-latitude="[[latitude]]" current-longitude="[[longitude]]">
+        [[item.name]]
+      </proximity-checkbox>
+    </template>
   </template>
   <script>
     Polymer({
@@ -44,26 +47,38 @@
         longitude: {
           type: Number,
           value: -85.282802
+        },
+        locations: {
+          type: Array,
+          readOnly: true,
+          value: function() { return [
+            {
+              latitude: 40.137244,
+              longitude: -85.284714,
+              name: "Reservoir Campgrounds"
+            },
+            {
+              latitude: 40.135326,
+              longitude: -85.278264,
+              name: "Prairie View Restaurant and Pub"
+            },
+            {
+              latitude: 40.132397,
+              longitude: -85.279364,
+              name: "Dry Dock Marina"
+            }
+          ];}
         }
       },
 
       _useCurrentLocation: function() {
         var that = this;
-        navigator.geolocation.getCurrentPosition((position) => {
+        navigator.geolocation.getCurrentPosition(function(position) {
           var coords = position.coords;
           that.latitude = coords.latitude;
           that.longitude = coords.longitude;
-          var marker = document.getElementsByTagName("google-map-marker");
-          var checkbox = document.getElementsByTagName("paper-checkbox");
-          for(i=0;i<marker.length;i++){
-            var distance = Math.sqrt(Math.pow((marker[i].latitude-that.latitude),2)
-              +Math.pow((marker[i].longitude-that.longitude),2));
-            if(distance<.0015){
-              checkbox[i].checked = true;
-            }
-          }
         });
-      }
+      },
     });
   </script>
 </dom-module>

--- a/src/proximity-checkbox.html
+++ b/src/proximity-checkbox.html
@@ -1,0 +1,67 @@
+<link rel="import" href="../bower_components/polymer/polymer.html">
+<link rel="import" href="../bower_components/paper-checkbox/paper-checkbox.html">
+
+<dom-module id="proximity-checkbox">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+    <paper-checkbox id="checkbox" checked="[[checked]]" disabled>
+      <content></content>
+    </paper-checkbox>
+  </template>
+  <script>
+    Polymer({
+      is: 'proximity-checkbox',
+      properties: {
+        markerLatitude: Number,
+        markerLongitude: Number,
+        currentLatitude: Number,
+        currentLongitude: Number,
+        distance: {
+          type: Number,
+          notify: true,
+          computed: '_updateDistance(currentLatitude,currentLongitude)'
+        },
+        checked: {
+          type: Boolean,
+          notify: true,
+          computed: '_updateChecked(distance)'
+        },
+        range: {
+          type: Number,
+          value: 0.0015
+        }
+      },
+
+      ready: function() {
+        this._updateDistance(this.currentLatitude, this.currentLongitude);
+      },
+
+      observers: [
+        '_updateDistance(currentLatitude, currentLongitude)'
+      ],
+
+      _updateDistance: function(currentLatitude, currentLongitude) {
+        var dx = currentLongitude - this.markerLongitude;
+        var dy = currentLatitude - this.markerLatitude;
+        return Math.sqrt(dx*dx + dy*dy);
+      },
+
+      _updateChecked: function(distance) {
+        if (distance < this.range) {
+          return true;
+        }
+        // Have we never been checked?
+        else if (this.checked === undefined){
+          return false;
+        }
+        else {
+          return this.checked;
+        }
+      }
+    });
+  </script>
+</dom-module>

--- a/test/index.html
+++ b/test/index.html
@@ -21,9 +21,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <body>
     <script>
       WCT.loadSuites([
-        // TODO put actual test suites here
-        //'my-view1.html?dom=shady',
-        //'my-view1.html?dom=shadow',
+        'proximity-checkbox_test.html?dom=shady',
+        'proximity-checkbox_test.html?dom=shadow',
       ]);
     </script>
   </body>

--- a/test/proximity-checkbox_test.html
+++ b/test/proximity-checkbox_test.html
@@ -1,0 +1,96 @@
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>proximity-checkbox tdd-test</title>
+
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../bower_components/web-component-tester/browser.js"></script>
+
+    <link rel="import" href="../src/proximity-checkbox.html">
+  </head>
+  <body>
+
+  <test-fixture id="at-location">
+    <template>
+      <proximity-checkbox
+        marker-latitude = "10"
+        marker-longitude = "10"
+        current-latitude = "10"
+        current-longitude = "10">
+      </proximity-checkbox>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="off-location-within-range">
+    <template>
+      <proximity-checkbox
+        marker-latitude = "10"
+        marker-longitude = "10"
+        current-latitude = "13"
+        current-longitude = "14"
+        range="10">
+      </proximity-checkbox>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="off-location-out-of-range">
+    <template>
+      <proximity-checkbox
+        marker-latitude = "10"
+        marker-longitude = "10"
+        current-latitude = "13"
+        current-longitude = "14"
+        range="0.0015">
+      </proximity-checkbox>
+    </template>
+  </test-fixture>
+
+  <script>
+    suite('proximity tests at location', function() {
+      var element;
+
+      setup(function() {
+        element = fixture('at-location');
+      });
+
+      test('distance is zero at exact location', function() {
+        assert.equal(0, element.distance);
+      });
+
+    });
+
+    suite('proximity tests away from location', function() {
+      var element;
+
+      setup(function() {
+        element = fixture('off-location-within-range');
+      });
+
+      test('distance is computed correctly for 3/4/5 triangle', function() {
+        assert.equal(5, element.distance);
+      });
+
+      test('checkbox is marked since distance < range', function() {
+        assert.equal(true, element.checked);
+      });
+    });
+
+    suite('proximity tests away from location and out of range', function() {
+      var element;
+
+      setup(function() {
+        element = fixture('off-location-out-of-range');
+      });
+
+      test('distance is computed correctly for 3/4/5 triangle', function() {
+        assert.equal(5, element.distance);
+      });
+
+      test('checkbox is unmarked', function() {
+        assert.equal(false, element.checked);
+      })
+    })
+  </script>
+
+  </body>
+</html>


### PR DESCRIPTION
This includes two major changes: adding `proximity-checkbox` and using a
data object.

`proximity-checkbox` is a new element that checks itself when the user
gets near. Like the previous implementation, it is "sticky" in that once
checked, it cannot be unchecked. Unit tests verify its behavior, which is
important since--as of this commit--there is no way to spoof location.

Both `proximity-checkbox` and `google-map-marker` needed location information,
so to remove the redundancy, I introduced a `locations` data element
to `map-view`. The `dom-repeat` templates allow you to stamp out different
elements per array item, which is now done for both the markers and the
checkboxes.