### PR TITLE
Align several screens with BSU prototype

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -2,6 +2,7 @@
   "entrypoint": "index.html",
   "shell": "src/prairie-creek-game/prairie-creek-game.html",
   "fragments": [
+    "src/arrival-view/arrival-view.html",
     "src/checklist-view/checklist-view.html",
     "src/collection-view/collection-view.html",
     "src/intro-view/intro-view.html",

--- a/src/arrival-view/arrival-view.html
+++ b/src/arrival-view/arrival-view.html
@@ -1,0 +1,32 @@
+<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import" href="../../bower_components/paper-button/paper-button.html">
+
+<link rel="import" href="../view-behavior/view-behavior.html">
+
+<dom-module id="arrival-view">
+  <template>
+    <style>
+      :host {
+        display: block;
+      }
+    </style>
+    You have arrived at [[locationName]]
+    <paper-button raised on-tap="_next">Confirm</paper-button>
+  </template>
+  <script>
+    Polymer({
+      is: 'arrival-view',
+      behaviors: [ ViewBehavior ],
+      properties: {
+        locationName: {
+          type: String,
+          value: '(Unspecified location name)'
+        }
+      },
+
+      _next: function() {
+        this._goToPage('timer');
+      }
+    });
+  </script>
+</dom-module>

--- a/src/intro-view/intro-view.html
+++ b/src/intro-view/intro-view.html
@@ -12,7 +12,6 @@
     </style>
     <h1>Visit all 3 locations found on the map</h1>
     <paper-button raised on-tap="_back">Back</paper-button>
-    <paper-button raised on-tap="_skip">Skip</paper-button>
     <paper-button raised on-tap="_next">Next</paper-button>
   </template>
   <script>
@@ -22,10 +21,6 @@
 
       _back: function() {
         this._goToPage('title');
-      },
-
-      _skip: function(){
-        this._goToPage('map');
       },
 
       _next: function() {

--- a/src/map-view/map-view.html
+++ b/src/map-view/map-view.html
@@ -37,7 +37,7 @@
 
       <div class="debugging-and-temporary">
         <paper-button raised on-tap="_useCurrentLocation">Use Current Location</paper-button>
-        <paper-button raised on-tap="_next">Go to timer</paper-button>
+        <paper-button raised on-tap="_next">Fake arrival</paper-button>
       </div>
     </div>
   </template>
@@ -70,7 +70,7 @@
       },
 
       _next: function() {
-        this._goToPage('timer');
+        this._goToPage('arrival');
       }
     });
   </script>

--- a/src/map-view/map-view.html
+++ b/src/map-view/map-view.html
@@ -31,20 +31,14 @@
         </google-map-marker>
       </google-map>
 
-      <paper-button raised on-tap="_useCurrentLocation">Use Current Location</paper-button>
-      <paper-input type="number" id="latitudeOverride" label="Latitude"></paper-input>
-      <paper-input type="number" id="longitudeOverride" label="Longitude"></paper-input>
-      <paper-button raised on-tap="_overrideLocation">Override Location</paper-button>
-      <paper-button raised on-tap="_next">Go to timer</paper-button>
-      <br>
-      <h1>This is a checkbox demo.</h1>
-      <template is="dom-repeat" items="[[locations]]" item="item">
-        <proximity-checkbox
-          marker-latitude="[[item.latitude]]" marker-longitude="[[item.longitude]]"
-          current-latitude="[[latitude]]" current-longitude="[[longitude]]">
-          [[item.name]]
-        </proximity-checkbox>
-      </template>
+      <p>
+        Please visit one of these locations.
+      </p>
+
+      <div class="debugging-and-temporary">
+        <paper-button raised on-tap="_useCurrentLocation">Use Current Location</paper-button>
+        <paper-button raised on-tap="_next">Go to timer</paper-button>
+      </div>
     </div>
   </template>
   <script>
@@ -73,11 +67,6 @@
           that.latitude = coords.latitude;
           that.longitude = coords.longitude;
         });
-      },
-
-      _overrideLocation: function() {
-        this.latitude = this.$.latitudeOverride.value;
-        this.longitude = this.$.longitudeOverride.value;
       },
 
       _next: function() {

--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -20,6 +20,7 @@
       <title-view name="title" route-data="{{routeData}}"></title-view>
       <intro-view name="intro" route-data="{{routeData}}"></intro-view>
       <map-view name="map" locations="[[mapData]]" route-data="{{routeData}}"></map-view>
+      <arrival-view name="arrival" route-data="{{routeData}}"></arrival-view>
       <timer-view name="timer" route-data="{{routeData}}"></timer-view>
       <checklist-view name="checklist" route-data="{{routeData}}"></checklist-view>
       <wudgie-view name="wudgie" route-data="{{routeData}}"></wudgie-view>

--- a/src/timer-view/timer-view.html
+++ b/src/timer-view/timer-view.html
@@ -10,13 +10,23 @@
         display: block;
       }
     </style>
-    Timer view placeholder
+    [[prompt]]
+    <div>
+      (Timer will go here)
+    </div>
     <paper-button raised on-tap="_next">Go to checklist</paper-button>
   </template>
   <script>
     Polymer({
       is: 'timer-view',
       behaviors: [ViewBehavior],
+
+      properties: {
+        prompt: {
+          type: String,
+          value: "Listen to what's around wherever you are (placeholder)",
+        }
+      },
 
       _next: function() {
         this._goToPage('checklist');

--- a/src/title-view/title-view.html
+++ b/src/title-view/title-view.html
@@ -15,14 +15,14 @@
     <h1>Ball State Hunt</h1>
     <img src="../../images/charlie.png"></img>
     <h2>Please proceed to Ball State University to play</h2>
-    <paper-button raised on-tap="_directions">Directions</paper-button>
+    <paper-button raised on-tap="_start">Play</paper-button>
   </template>
   <script>
     Polymer({
       is: 'title-view',
       behaviors: [ViewBehavior],
 
-      _directions: function() {
+      _start: function() {
         this._goToPage('intro');
       }
     });


### PR DESCRIPTION
This is a mix of changes across a few views, including a new `arrival-view`. It's not a complete adaptation to the BSU paper prototype made by @dmwisenberg, but it gets us closer.

There are some hooks here to show, maybe, how to use an improved `hot-spot-id` element to bind current location to these views, so they can manage themselves. There's a discussion (or at least a few more notes) about this over on Slack.

I'd squash these into one merge. Each individually is not very interesting.