### PR TITLE
Write player state information to map data

### DIFF
--- a/src/checklist-view/checklist-view.html
+++ b/src/checklist-view/checklist-view.html
@@ -47,17 +47,21 @@
 
       _next: function() {
         this.currentSite.visited = true;
-        var visitedAllSites = true;
-        for (var i = 0; i < this.mapData.length; i++) {
-          if (!this.mapData[i].visited) {
-            visitedAllSites = false;
-          }
-        }
-        if (visitedAllSites) {
+      
+        if (this._visitedAllSites()) {
           this.nextPage = 'wudgie';
         }
 
         this._goToPage(this.nextPage);
+      },
+
+      _visitedAllSites: function() {
+        for (var i = 0; i < this.mapData.length; i++) {
+          if (!this.mapData[i].visited) {
+            return false;
+          }
+        }
+        return true;
       }
     });
   </script>

--- a/src/checklist-view/checklist-view.html
+++ b/src/checklist-view/checklist-view.html
@@ -33,11 +33,6 @@
       properties: {
         currentSite: Object,
         mapData: Object,
-        responses: {
-          type: Array,
-          notify: true,
-          value: function() { return [] }
-        },
         nextPage: {
           type: String,
           value: 'map'
@@ -47,17 +42,7 @@
       _onCheckboxTap: function(event) {
         const checkbox = event.target;
         const item = event.target.item;
-        var copyIndex = -1;
-        for(var i = 0;i < this.responses.length;i++) {
-          if(item.text == this.responses[i].text) {
-            copyIndex = i;
-         }
-        }
-        if(copyIndex == -1) {
-          this.push('responses', item);
-        } else {
-          this.splice('responses', copyIndex, 1);
-        }
+        this.currentSite.responses[checkbox.index].selected = checkbox.checked;
       },
 
       _next: function() {

--- a/src/checklist-view/checklist-view.html
+++ b/src/checklist-view/checklist-view.html
@@ -32,19 +32,16 @@
       behaviors: [ViewBehavior],
       properties: {
         currentSite: Object,
-        visitedSites: {
-          type: Number,
-          value: 0,
-        },
-        totalSites: {
-          type: Number,
-          value: 3,
-        },
+        mapData: Object,
         responses: {
           type: Array,
           notify: true,
           value: function() { return [] }
         },
+        nextPage: {
+          type: String,
+          value: 'map'
+        }
       },
 
       _onCheckboxTap: function(event) {
@@ -63,22 +60,19 @@
         }
       },
 
-      _haveVisited: function(){
-        if(this.currentSite.visited == false){
-          this.currentSite.visited = true;
-          this.visitedSites += 1;
-        }
-      },
-
       _next: function() {
         this.currentSite.visited = true;
-        this._haveVisited();
-        if(this.visitedSites < this.totalSites){
-          this._goToPage('map');
+        var visitedAllSites = true;
+        for (var i = 0; i < this.mapData.length; i++) {
+          if (!this.mapData[i].visited) {
+            visitedAllSites = false;
+          }
         }
-        if(this.visitedSites == this.totalSites){
-          this._goToPage('wudgie');
+        if (visitedAllSites) {
+          this.nextPage = 'wudgie';
         }
+
+        this._goToPage(this.nextPage);
       }
     });
   </script>

--- a/src/checklist-view/checklist-view.html
+++ b/src/checklist-view/checklist-view.html
@@ -24,7 +24,7 @@
           [[item.text]]
       </paper-checkbox>
     </template>
-    <paper-button raised on-tap="_next">Next</paper-button>
+    <paper-button id="submit" raised on-tap="_next">Next</paper-button>
   </template>
   <script>
     Polymer({
@@ -71,6 +71,7 @@
       },
 
       _next: function() {
+        this.currentSite.visited = true;
         this._haveVisited();
         if(this.visitedSites < this.totalSites){
           this._goToPage('map');

--- a/src/checklist-view/checklist-view.html
+++ b/src/checklist-view/checklist-view.html
@@ -47,11 +47,7 @@
 
       _next: function() {
         this.currentSite.visited = true;
-      
-        if (this._visitedAllSites()) {
-          this.nextPage = 'wudgie';
-        }
-
+        this.nextPage = this._visitedAllSites() ? 'wudgie' : 'map';
         this._goToPage(this.nextPage);
       },
 

--- a/src/map-data/map-data.html
+++ b/src/map-data/map-data.html
@@ -2,83 +2,88 @@
 
 <dom-module id="map-data">
   <script>
+    const _default = [
+      {
+        latitude: 40.203797,
+        longitude: -85.408037,
+        name: "Bell Tower",
+        range: 0.0001,
+        question: 'What did you smell?',
+        visited: false,
+        responses: [
+          {
+            text: 'Fresh air',
+            value: +2
+          },
+          {
+            text: 'Exhaust fumes',
+            value: -2
+          },
+          {
+            text: 'Fried food',
+            value: -1
+          }
+        ]
+      },
+      {
+        latitude: 40.203295,
+        longitude: -85.407271,
+        name: "Frog Baby",
+        range: 0.0001,
+        question: 'What did you see?',
+        visited: false,
+        responses: [
+          {
+            text: 'Water',
+            value: +3
+          },
+          {
+            text: 'Plants',
+            value: +2
+          },
+          {
+            text: 'Litter',
+            value: -4
+          }
+        ]
+      },
+      {
+        latitude: 40.204366,
+        longitude: -85.406887,
+        name: "Architecture Building",
+        range: 0.0001,
+        question: 'What did you hear?',
+        visited: false,
+        responses: [
+          {
+            text: 'Birds',
+            value: +2
+          },
+          {
+            text: 'Music',
+            value: 0
+          },
+          {
+            text: 'Traffic',
+            value: -3
+          }
+        ]
+      }
+    ];
+
     Polymer({
       is: 'map-data',
       properties: {
         data: {
-          type: Array,
-          notify: true,
-          value: function(){
-            return [
-              {
-                latitude: 40.203797,
-                longitude: -85.408037,
-                name: "Bell Tower",
-                range: 0.0001,
-                question: 'What did you smell?',
-                visited: false,
-                responses: [
-                  {
-                    text: 'Fresh air',
-                    value: +2
-                  },
-                  {
-                    text: 'Exhaust fumes',
-                    value: -2
-                  },
-                  {
-                    text: 'Fried food',
-                    value: -1
-                  }
-                ]
-              },
-              {
-                latitude: 40.203295,
-                longitude: -85.407271,
-                name: "Frog Baby",
-                range: 0.0001,
-                question: 'What did you see?',
-                visited: false,
-                responses: [
-                  {
-                    text: 'Water',
-                    value: +3
-                  },
-                  {
-                    text: 'Plants',
-                    value: +2
-                  },
-                  {
-                    text: 'Litter',
-                    value: -4
-                  }
-                ]
-              },
-              {
-                latitude: 40.204366,
-                longitude: -85.406887,
-                name: "Architecture Building",
-                range: 0.0001,
-                question: 'What did you hear?',
-                visited: false,
-                responses: [
-                  {
-                    text: 'Birds',
-                    value: +2
-                  },
-                  {
-                    text: 'Music',
-                    value: 0
-                  },
-                  {
-                    text: 'Traffic',
-                    value: -3
-                  }
-                ]
-              }
-            ];
+          type: Object,
+          value: function () {
+            return JSON.parse(JSON.stringify(_default));
           }
         }
+      },
+
+      reset: function () {
+        this.data = JSON.parse(JSON.stringify(_default));
       }
     });
   </script>

--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -79,6 +79,10 @@
 
           _pageChanged: function(page) {
             if (page) {
+              if (page === 'title') {
+                this.$$('map-data').reset();
+              }
+
               var resolvedPageUrl = this.resolveUrl('../' + page + '-view/' + page + '-view.html');
               this.importHref(resolvedPageUrl, null, this._showPage404, true);
             }

--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -34,6 +34,7 @@
       <timer-view name="timer" route-data="{{routeData}}"></timer-view>
       <checklist-view
         name="checklist"
+        map-data="{{mapData}}"
         current-site="[[currentSite]]"
         route-data="{{routeData}}">
       </checklist-view>

--- a/test/checklist-view_test.html
+++ b/test/checklist-view_test.html
@@ -1,17 +1,15 @@
 <html>
 
 <head>
-  <meta name="viewport"
-        content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-    <title>checklist-view bdd test</title>
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+  <title>checklist-view bdd test</title>
 
-    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-    <script src="../bower_components/web-component-tester/browser.js"></script>
-    <script src="../bower_components/iron-test-helpers/mock-interactions.js"></script>
+  <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+  <script src="../bower_components/web-component-tester/browser.js"></script>
+  <script src="../bower_components/iron-test-helpers/mock-interactions.js"></script>
 
 
-    <link rel="import"
-          href="../src/checklist-view/checklist-view.html">
+  <link rel="import" href="../src/checklist-view/checklist-view.html">
 
 </head>
 
@@ -25,19 +23,6 @@
 
 
   <script>
-    describe('no items checked', function () {
-      var element;
-
-      before(function () {
-        element = fixture('basic');
-      });
-
-      it('sets responses to empty array', function () {
-        expect(element.responses).to.exist;
-        expect(element.responses).to.be.empty;
-      });
-    });
-
     const site = {
       name: "Bell Tower",
       question: 'What did you smell?',
@@ -57,7 +42,9 @@
       ]
     };
 
-    describe('correct items are checked', function () {
+
+
+    describe('checklist-view with sample site data', function () {
       var element;
 
       beforeEach(function (done) {
@@ -66,43 +53,78 @@
         flush(done);
       });
 
-      it('sets responses to contain only the right item', function () {
-        var checkbox = element.$$('.checkbox');
+      function tapCheckbox(index) {
+        var checkbox = Polymer.dom(element.root).querySelectorAll('.checkbox')[index];
         MockInteractions.tap(checkbox);
-        expect(element.responses.length).to.equal(1);
-        expect(element.responses[0]).to.deep.equal(site.responses[0]);
+      }
+
+
+      describe('no items checked', function () {
+        it('sets responses to empty array', function () {
+          expect(element.responses).to.exist;
+          expect(element.responses).to.be.empty;
+        });
       });
 
-      it('sets responses to be empty', function () {
-        var checkbox = element.$$('.checkbox');
-        MockInteractions.tap(checkbox);
-        MockInteractions.tap(checkbox);
-        expect(element.responses).to.exist;
-        expect(element.responses).to.empty;
+      describe('the first item is selected', function () {
+        beforeEach(function () {
+          tapCheckbox(0);
+        });
+
+        it('sets responses to contain one item', function () {
+          expect(element.responses.length).to.equal(1);
+        });
+
+        it('sets response to contain the first site response', function () {
+          expect(element.responses[0]).to.deep.equal(site.responses[0]);
+        })
       });
 
-      it('sets responses to contain two items', function() {
-        var checkbox1 = Polymer.dom(element.root).querySelectorAll('.checkbox')[0];
-        var checkbox2 = Polymer.dom(element.root).querySelectorAll('.checkbox')[1];
-        MockInteractions.tap(checkbox1);
-        MockInteractions.tap(checkbox2);
-        expect(element.responses.length).to.equal(2);
-        expect(element.responses[0]).to.deep.equal(site.responses[0]);
-        expect(element.responses[1]).to.deep.equal(site.responses[1]);
+      describe('the first item is selected then deselected', function () {
+        beforeEach(function () {
+          tapCheckbox(0);
+          tapCheckbox(0);
+        });
+
+        it('sets responses to be empty', function () {
+          expect(element.responses).to.exist;
+          expect(element.responses).to.empty;
+        });
       });
 
-      it('sets responses to contain only the right item', function() {
-        var checkbox1 = Polymer.dom(element.root).querySelectorAll('.checkbox')[0];
-        var checkbox2 = Polymer.dom(element.root).querySelectorAll('.checkbox')[1];
-        MockInteractions.tap(checkbox1);
-        MockInteractions.tap(checkbox2);
-        MockInteractions.tap(checkbox1);
-        expect(element.responses.length).to.equal(1);
-        expect(element.responses[0]).to.deep.equal(site.responses[1]);
+      describe('the first and then second items are selected', function () {
+        beforeEach(function () {
+          tapCheckbox(0);
+          tapCheckbox(1);
+        });
+
+        it('sets responses to contain two items', function () {
+          expect(element.responses.length).to.equal(2);
+        });
+
+        it('contains the right items', function () {
+          expect(element.responses[0]).to.deep.equal(site.responses[0]);
+          expect(element.responses[1]).to.deep.equal(site.responses[1]);
+        });
+      });
+
+      describe('the first and second are selected, then the first deselected', function () {
+        beforeEach(function () {
+          tapCheckbox(0);
+          tapCheckbox(1);
+          tapCheckbox(0);
+        });
+
+        it('response length is 1', function () {
+          expect(element.responses.length).to.equal(1);
+        });
+
+        it('sets response to only the second item', function () {
+          expect(element.responses[0]).to.deep.equal(site.responses[1]);
+        });
       });
     });
   </script>
-
 </body>
 
 </html>

--- a/test/checklist-view_test.html
+++ b/test/checklist-view_test.html
@@ -1,15 +1,17 @@
 <html>
 
 <head>
-  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <title>checklist-view bdd test</title>
+  <meta name="viewport"
+        content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>checklist-view bdd test</title>
 
-  <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../bower_components/web-component-tester/browser.js"></script>
-  <script src="../bower_components/iron-test-helpers/mock-interactions.js"></script>
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../bower_components/web-component-tester/browser.js"></script>
+    <script src="../bower_components/iron-test-helpers/mock-interactions.js"></script>
 
 
-  <link rel="import" href="../src/checklist-view/checklist-view.html">
+    <link rel="import"
+          href="../src/checklist-view/checklist-view.html">
 
 </head>
 
@@ -23,30 +25,45 @@
 
 
   <script>
-    const site = {
-      name: "Bell Tower",
-      question: 'What did you smell?',
-      responses: [
-        {
-          text: 'Fresh air',
-          value: +2
-        },
-        {
-          text: 'Exhaust fumes',
-          value: -2
-        },
-        {
-          text: 'Fried food',
-          value: -1
-        }
-      ]
-    };
+    const allSites = [
+      {
+        name: "Bell Tower",
+        question: 'What did you smell?',
+        responses: [
+          {
+            text: 'Fresh air',
+            value: +2
+          },
+          {
+            text: 'Exhaust fumes',
+            value: -2
+          },
+          {
+            text: 'Fried food',
+            value: -1
+          }
+        ]
+      },
+      {
+        name: "A second site",
+        question: "Will this be read?",
+        responses: [
+          {
+            text: 'No',
+            value: 0
+          }
+        ]
+      }
+    ];
+
+    const site = allSites[0];
 
     describe('checklist-view with sample site data', function () {
       var element;
 
       beforeEach(function (done) {
         element = fixture('basic');
+        element.mapData = clone(allSites);
         element.currentSite = clone(site);
         flush(done);
       });
@@ -125,10 +142,25 @@
         });
       });
 
-      describe('the submit button is pressed', function() {
-        it('marks the site as visited', function() {
+      describe('the submit button is pressed', function () {
+        beforeEach(function () {
           MockInteractions.tap(element.$.submit);
+        });
+        it('marks the site as visited', function () {
           expect(element.currentSite.visited).to.be.true;
+        });
+        it('routes to map view since there are more unmarked sites', function () {
+          expect(element.nextPage).to.equal('map');
+        });
+      });
+
+      describe('the submit button is pressed and there are no unvisited sites', function () {
+        beforeEach(function () {
+          element.mapData = clone(site);
+          MockInteractions.tap(element.$.submit);
+        });
+        it('routes to wudgie view', function () {
+          expect(element.nextPage).to.equal('wudgie');
         });
       });
     });

--- a/test/checklist-view_test.html
+++ b/test/checklist-view_test.html
@@ -42,16 +42,18 @@
       ]
     };
 
-
-
     describe('checklist-view with sample site data', function () {
       var element;
 
       beforeEach(function (done) {
         element = fixture('basic');
-        element.currentSite = site;
+        element.currentSite = clone(site);
         flush(done);
       });
+
+      function clone(obj) {
+        return JSON.parse(JSON.stringify(obj));
+      }
 
       function tapCheckbox(index) {
         var checkbox = Polymer.dom(element.root).querySelectorAll('.checkbox')[index];

--- a/test/checklist-view_test.html
+++ b/test/checklist-view_test.html
@@ -1,8 +1,7 @@
 <html>
 
 <head>
-  <meta name="viewport"
-        content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
     <title>checklist-view bdd test</title>
 
     <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
@@ -10,134 +9,155 @@
     <script src="../bower_components/iron-test-helpers/mock-interactions.js"></script>
 
 
-    <link rel="import"
-          href="../src/checklist-view/checklist-view.html">
+    <link rel="import" href="../src/checklist-view/checklist-view.html">
 
 </head>
 
 <body>
-  <test-fixture id="basic">
-    <template>
+    <test-fixture id="basic">
+        <template>
       <checklist-view>
       </checklist-view>
     </template>
-  </test-fixture>
+    </test-fixture>
 
 
-  <script>
-    const allSites = [
-      {
-        name: "Bell Tower",
-        question: 'What did you smell?',
-        responses: [
-          {
-            text: 'Fresh air',
-            value: +2
-          },
-          {
-            text: 'Exhaust fumes',
-            value: -2
-          },
-          {
-            text: 'Fried food',
-            value: -1
-          }
-        ]
-      },
-      {
-        name: "A second site",
-        question: "Will this be read?",
-        responses: [
-          {
-            text: 'No',
-            value: 0
-          }
-        ]
-      }
-    ];
+    <script>
+        const allSites = [{
+                name: "Bell Tower",
+                question: 'What did you smell?',
+                responses: [{
+                        text: 'Fresh air',
+                        value: +2
+                    },
+                    {
+                        text: 'Exhaust fumes',
+                        value: -2
+                    },
+                    {
+                        text: 'Fried food',
+                        value: -1
+                    }
+                ]
+            },
+            {
+                name: "A second site",
+                question: "Will this be read?",
+                responses: [{
+                    text: 'No',
+                    value: 0
+                }]
+            }
+        ];
 
-    const site = allSites[0];
+        const site = allSites[0];
 
-    describe('checklist-view with sample site data', function () {
-      var element;
+        describe('checklist-view with sample site data', function() {
+            var element;
 
-      beforeEach(function (done) {
-        element = fixture('basic');
-        element.mapData = clone(allSites);
-        element.currentSite = clone(site);
-        flush(done);
-      });
+            beforeEach(function(done) {
+                element = fixture('basic');
+                element.mapData = clone(allSites);
+                element.currentSite = clone(site);
+                flush(done);
+            });
 
-      function clone(obj) {
-        return JSON.parse(JSON.stringify(obj));
-      }
+            function clone(obj) {
+                return JSON.parse(JSON.stringify(obj));
+            }
 
-      function tapCheckbox(index) {
-        var checkbox = Polymer.dom(element.root).querySelectorAll('.checkbox')[index];
-        MockInteractions.tap(checkbox);
-      }
+            function tapCheckbox(index) {
+                var checkbox = Polymer.dom(element.root).querySelectorAll('.checkbox')[index];
+                MockInteractions.tap(checkbox);
+            }
 
-      function expectCheckboxSelected(index) {
-        expect(element.currentSite.responses[index].selected).to.be.true;
-      }
+            function expectCheckboxSelected(index) {
+                expect(element.currentSite.responses[index].selected).to.be.true;
+            }
 
-      function expectCheckboxNotSelected(index) {
-        expect(element.currentSite.responses[index].selected).to.be.false;
-      }
+            function expectCheckboxNotSelected(index) {
+                expect(element.currentSite.responses[index].selected).to.be.false;
+            }
 
-      describe('the first item is selected', function () {
-        beforeEach(function () {
-          tapCheckbox(0);
+            describe('the first item is selected', function() {
+                beforeEach(function() {
+                    tapCheckbox(0);
+                });
+
+                it('sets selected on first response', function() {
+                    expectCheckboxSelected(0);
+                })
+            });
+
+            describe('the first item is selected then deselected', function() {
+                beforeEach(function() {
+                    tapCheckbox(0);
+                    tapCheckbox(0);
+                });
+
+                it('marks first response as unselected', function() {
+                    expectCheckboxNotSelected(0);
+                });
+            });
+
+            describe('the second item is checked', function() {
+                beforeEach(function() {
+                    tapCheckbox(1);
+                });
+                it('marks the second response as selected', function() {
+                    expectCheckboxSelected(1);
+                });
+            });
+
+            describe('the submit button is pressed', function() {
+                beforeEach(function() {
+                    MockInteractions.tap(element.$.submit);
+                });
+                it('marks the site as visited', function() {
+                    expect(element.currentSite.visited).to.be.true;
+                });
+                it('routes to map view since there are more unmarked sites', function() {
+                    expect(element.nextPage).to.equal('map');
+                });
+            });
+
+            describe('routing as sites are visited', function() {
+
+                function visitSite(index) {
+                    element.currentSite = element.mapData[index];
+                    MockInteractions.tap(element.$.submit);
+                }
+
+                function resetMapData() {
+                    element.mapData = clone(allSites);
+                }
+
+                describe('the submit button is pressed and there are no unvisited sites', function() {
+                    beforeEach(function() {
+                        visitSite(0);
+                        visitSite(1);
+                    });
+
+                    it('routes to wudgie view', function() {
+                        expect(element.nextPage).to.equal('wudgie');
+                    });
+                });
+
+                describe('nextPage was wudgie from previous play, then locations are unmarked', function() {
+                    beforeEach(function() {
+                        visitSite(0);
+                        visitSite(1);
+                        resetMapData();
+                        visitSite(0);
+                    });
+
+                    it('routes to map view because some sites are unvisited', function() {
+                        expect(element.nextPage).to.equal('map');
+                    });
+                });
+            });
         });
-
-        it('sets selected on first response', function () {
-          expectCheckboxSelected(0);
-        })
-      });
-
-      describe('the first item is selected then deselected', function () {
-        beforeEach(function () {
-          tapCheckbox(0);
-          tapCheckbox(0);
-        });
-
-        it('marks first response as unselected', function () {
-          expectCheckboxNotSelected(0);
-        });
-      });
-
-      describe('the second item is checked', function() {
-        beforeEach(function() {
-          tapCheckbox(1);
-        });
-        it('marks the second response as selected', function() {
-          expectCheckboxSelected(1);
-        });
-      });
-
-      describe('the submit button is pressed', function () {
-        beforeEach(function () {
-          MockInteractions.tap(element.$.submit);
-        });
-        it('marks the site as visited', function () {
-          expect(element.currentSite.visited).to.be.true;
-        });
-        it('routes to map view since there are more unmarked sites', function () {
-          expect(element.nextPage).to.equal('map');
-        });
-      });
-
-      describe('the submit button is pressed and there are no unvisited sites', function () {
-        beforeEach(function () {
-          element.mapData = clone(site);
-          MockInteractions.tap(element.$.submit);
-        });
-        it('routes to wudgie view', function () {
-          expect(element.nextPage).to.equal('wudgie');
-        });
-      });
-    });
-  </script>
+    </script>
 </body>
 
 </html>

--- a/test/checklist-view_test.html
+++ b/test/checklist-view_test.html
@@ -58,7 +58,6 @@
         MockInteractions.tap(checkbox);
       }
 
-
       describe('no items checked', function () {
         it('sets responses to empty array', function () {
           expect(element.responses).to.exist;
@@ -121,6 +120,13 @@
 
         it('sets response to only the second item', function () {
           expect(element.responses[0]).to.deep.equal(site.responses[1]);
+        });
+      });
+
+      describe('the submit button is pressed', function() {
+        it('marks the site as visited', function() {
+          MockInteractions.tap(element.$.submit);
+          expect(element.currentSite.visited).to.be.true;
         });
       });
     });

--- a/test/checklist-view_test.html
+++ b/test/checklist-view_test.html
@@ -77,24 +77,21 @@
         MockInteractions.tap(checkbox);
       }
 
-      describe('no items checked', function () {
-        it('sets responses to empty array', function () {
-          expect(element.responses).to.exist;
-          expect(element.responses).to.be.empty;
-        });
-      });
+      function expectCheckboxSelected(index) {
+        expect(element.currentSite.responses[index].selected).to.be.true;
+      }
+
+      function expectCheckboxNotSelected(index) {
+        expect(element.currentSite.responses[index].selected).to.be.false;
+      }
 
       describe('the first item is selected', function () {
         beforeEach(function () {
           tapCheckbox(0);
         });
 
-        it('sets responses to contain one item', function () {
-          expect(element.responses.length).to.equal(1);
-        });
-
-        it('sets response to contain the first site response', function () {
-          expect(element.responses[0]).to.deep.equal(site.responses[0]);
+        it('sets selected on first response', function () {
+          expectCheckboxSelected(0);
         })
       });
 
@@ -104,41 +101,17 @@
           tapCheckbox(0);
         });
 
-        it('sets responses to be empty', function () {
-          expect(element.responses).to.exist;
-          expect(element.responses).to.empty;
+        it('marks first response as unselected', function () {
+          expectCheckboxNotSelected(0);
         });
       });
 
-      describe('the first and then second items are selected', function () {
-        beforeEach(function () {
-          tapCheckbox(0);
+      describe('the second item is checked', function() {
+        beforeEach(function() {
           tapCheckbox(1);
         });
-
-        it('sets responses to contain two items', function () {
-          expect(element.responses.length).to.equal(2);
-        });
-
-        it('contains the right items', function () {
-          expect(element.responses[0]).to.deep.equal(site.responses[0]);
-          expect(element.responses[1]).to.deep.equal(site.responses[1]);
-        });
-      });
-
-      describe('the first and second are selected, then the first deselected', function () {
-        beforeEach(function () {
-          tapCheckbox(0);
-          tapCheckbox(1);
-          tapCheckbox(0);
-        });
-
-        it('response length is 1', function () {
-          expect(element.responses.length).to.equal(1);
-        });
-
-        it('sets response to only the second item', function () {
-          expect(element.responses[0]).to.deep.equal(site.responses[1]);
+        it('marks the second response as selected', function() {
+          expectCheckboxSelected(1);
         });
       });
 

--- a/test/index.html
+++ b/test/index.html
@@ -27,6 +27,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         'current-site/current-site_test.html?dom=shadow',
         'checklist-view_test.html?dom=shady',
         'checklist-view_test.html?dom=shadow',
+        'prairie-creek-game_test.html?dom=shady',
+        'prairie-creek-game_test.html?dom=shadow',
+        'map-data_test.html?dom=shady',
+        'map-data_test.html?dom=shadow'
       ]);
     </script>
   </body>

--- a/test/map-data_test.html
+++ b/test/map-data_test.html
@@ -1,0 +1,49 @@
+<html>
+
+<head>
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>map-data bdd test</title>
+
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../bower_components/web-component-tester/browser.js"></script>
+
+
+    <link rel="import" href="../src/map-data/map-data.html">
+
+</head>
+
+<body>
+    <test-fixture id="basic">
+        <template>
+            <map-data></map-data>
+        </template>
+    </test-fixture>
+
+
+    <script>
+        describe('the map-data element', function () {
+            var element;
+
+            beforeEach(function (done) {
+                element = fixture('basic');
+                flush(done);
+            });
+
+            describe('element initialization', function () {
+                it('has data', function () {
+                    expect(element.data).to.exist;
+                });
+            });
+
+            describe('reset', function () {
+                it('resets the data', function() {
+                    element.data.touched = true;
+                    element.reset();
+                    expect(element.data.touched).to.be.undefined;
+                })
+            });
+        });
+    </script>
+</body>
+
+</html>

--- a/test/prairie-creek-game_test.html
+++ b/test/prairie-creek-game_test.html
@@ -1,0 +1,52 @@
+<html>
+
+<head>
+  <meta name="viewport"
+        content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+    <title>prairie-creek-game bdd test</title>
+
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../bower_components/web-component-tester/browser.js"></script>
+
+
+    <link rel="import"
+          href="../src/prairie-creek-game/prairie-creek-game.html">
+
+</head>
+
+<body>
+  <test-fixture id="basic">
+    <template>
+      <prairie-creek-game>
+      </prairie-creek-game>
+    </template>
+  </test-fixture>
+
+
+  <script>
+    describe('navigate away and back to title view', function () {
+      var element;
+
+      beforeEach(function (done) {
+        element = fixture('basic');
+        flush(done);
+      });
+
+      it('resets the map data', function(done) {
+        element.mapData = {};
+
+        element.routeData.page = 'foo';
+        flush(function() {
+            element.routeData.page = 'title';
+            flush(function() {
+                expect(element.mapData.touched).to.not.deep.equal({});
+                done();
+            });
+        });
+        
+      });
+    });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
This is a proposed redesign of `checklist-view` to make it more manageable. Previously it had used several state variables, and some information was written to `currentSite` (visited or not), while some was recorded in an array (responses). That was the worst of both worlds. I tried my hand at keeping the map data immutable, but this led to the need for a lot of duplication. This pull request represents my latest best effort, which embraces the "write player state information to map data" philosophy.

Now, rather than writing selections to a `responses` array, this element will simply mark the responses in the current site as selected or not. 

I spent some time cleaning up the presentation of the tests as well. I think the current approach is good, with one outer context that sets up a common fixture, then nested `describe` test suites. Note that the actual tests are much easier when we're just looking for whether something is marked selected, rather than the old approach that required running through arrays to see if the same data were copied over from `currentSite` over to `responses`.