### PR TITLE
Control developer mode through URL

### DIFF
--- a/src/map-view/map-view.html
+++ b/src/map-view/map-view.html
@@ -36,10 +36,12 @@
       <br>
       Currently at [[currentSite.name]]
 
-      <div class="debugging-and-temporary">
-        <paper-button raised on-tap="_useCurrentLocation">Use Current Location</paper-button>
-      </div>
-      <paper-button raised on-tap="_debugModeOn">Debug Mode</paper-button>
+      <template is="dom-if" if$="[[devMode]]">
+        <div class="debugging">
+          <paper-button raised on-tap="_useCurrentLocation">Use Current Location</paper-button>
+          <paper-button raised on-tap="_debugModeOn">Enable Location Override</paper-button>
+        </div>
+      </template>
     </div>
   </template>
   <script>
@@ -60,6 +62,10 @@
         },
         currentSite: {
           type: Object
+        },
+        devMode: {
+          type: Boolean,
+          value: false
         }
       },
 
@@ -75,7 +81,6 @@
 
       _debugModeOn: function() {
         this.$.map.setAttribute('click-events', true);
-        console.log("Debug Mode On");
       },
 
       _debugLocation: function(event){

--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -14,7 +14,8 @@
 
   <template>
     <app-location route="{{route}}" use-hash-as-path></app-location>
-    <app-route route="{{route}}" pattern="/:page" data="{{routeData}}"></app-route>
+    <app-route route="{{route}}" pattern="/:page" data="{{routeData}}" tail="{{tail}}"></app-route>
+    <app-route route="{{tail}}" pattern="/:d" data="{{tailData}}"></app-route>
     <map-data data="{{mapData}}"></map-data>
     <user-location latitude="{{latitude}}" longitude="{{longitude}}" update-rate="{{updateRate}}"></user-location>
     <current-site latitude="[[latitude]]" longitude="[[longitude]]" sites="[[mapData]]" site="{{currentSite}}"></current-site>
@@ -28,10 +29,11 @@
         latitude="{{latitude}}"
         longitude="{{longitude}}"
         current-site="[[currentSite]]"
-        route-data="{{routeData}}">
+        route-data="{{routeData}}"
+        dev-mode="[[devMode]]">
       </map-view>
       <arrival-view name="arrival" route-data="{{routeData}}" location-name="[[currentSite.name]]"></arrival-view>
-      <timer-view name="timer" route-data="{{routeData}}"></timer-view>
+      <timer-view name="timer" route-data="{{routeData}}" dev-mode="[[devMode]]"></timer-view>
       <checklist-view
         name="checklist"
         map-data="{{mapData}}"
@@ -62,6 +64,12 @@
               currentSite: {
                 type: Object,
                 notify: true
+              },
+              tailData: Object,
+              devMode: {
+                type: Boolean,
+                notify: true,
+                computed: '_checkDebugMode(tailData)'
               }
           },
 
@@ -91,6 +99,16 @@
           _showPage404: function() {
               this.set('routeData.page', 'missing');
           },
+
+          _checkDebugMode: function(data) {
+            if (data.d) {
+              console.log('Debug mode enabled');
+              return true;
+            }
+            else {
+              return false;
+            }
+          }
       });
   </script>
 </dom-module>

--- a/src/shared-styles/shared-styles.html
+++ b/src/shared-styles/shared-styles.html
@@ -14,7 +14,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <dom-module id="shared-styles">
   <template>
     <style>
-
+      .debugging {
+        background-color: #eeddee;
+      }
     </style>
   </template>
 </dom-module>

--- a/src/timer-view/timer-view.html
+++ b/src/timer-view/timer-view.html
@@ -2,11 +2,12 @@
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../bower_components/iron-timer/iron-timer.html">
 
+<link rel="import" href="../shared-styles/shared-styles.html">
 <link rel="import" href="../view-behavior/view-behavior.html">
 
 <dom-module id="timer-view">
   <template>
-    <style>
+    <style include="shared-styles">
       :host {
         display: block;
       }
@@ -23,6 +24,11 @@
       disabled$="[[!_hasNoSecondsRemaining(secondsRemaining)]]">
         Go to checklist
     </paper-button>
+    <template is="dom-if" if$="[[devMode]]">
+      <div class="debugging">
+        <paper-button raised on-tap="_next">Skip</paper-button>
+      </div>
+    </template>
   </template>
   <script>
     Polymer({
@@ -38,6 +44,11 @@
         secondsRemaining: {
           type: Number
         },
+
+        devMode: {
+          type: Boolean,
+          value: false
+        }
       },
 
       observers: [


### PR DESCRIPTION
Developer mode is enabled by loading any page with a "/d" at the end
of the url, such as with `http://localhost:8080/#/title/d`. Once you
set this, it "sticks" even though the extra flag disappears as you
navigate. The only way to disable developer mode is to reload a page
manually while omitting the /d flag.

Developer mode is currently integrated into two views:

- `timer-view` adds a skip button

- `map-view` hides the "use current location" and "override location"
  buttons unless dev mode is enabled

I have added a ".debugging" class to the `shared-styles`
stylesheet. All of the content that is part of a dev-mode-only element
can implement this class and be displayed in a lovely light magenta.

Note that the behavior of `map view`'s debugging features haven't
changed, although they could use some work---making location override
modal and turning off GPS location while it's on, for example. That's
not part of this commit, however.