### PR TITLE
Specify site prompts in map data

### DIFF
--- a/src/map-data/map-data.html
+++ b/src/map-data/map-data.html
@@ -8,6 +8,7 @@
         longitude: -85.408037,
         name: "Bell Tower",
         range: 0.0001,
+        prompt: 'Breathe deeply and consider what you smell.',
         question: 'What did you smell?',
         visited: false,
         responses: [
@@ -30,6 +31,7 @@
         longitude: -85.407271,
         name: "Frog Baby",
         range: 0.0001,
+        prompt: 'Observe your surroundings.',
         question: 'What did you see?',
         visited: false,
         responses: [
@@ -52,6 +54,7 @@
         longitude: -85.406887,
         name: "Architecture Building",
         range: 0.0001,
+        prompt: 'Take a moment to listen to the world around you.',
         question: 'What did you hear?',
         visited: false,
         responses: [

--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -31,7 +31,11 @@
         route-data="{{routeData}}">
       </map-view>
       <arrival-view name="arrival" route-data="{{routeData}}" location-name="[[currentSite.name]]"></arrival-view>
-      <timer-view name="timer" route-data="{{routeData}}"></timer-view>
+      <timer-view 
+        name="timer"
+        prompt="[[currentSite.prompt]]"
+        route-data="{{routeData}}">
+      </timer-view>
       <checklist-view
         name="checklist"
         map-data="{{mapData}}"

--- a/src/timer-view/timer-view.html
+++ b/src/timer-view/timer-view.html
@@ -30,9 +30,10 @@
       behaviors: [ViewBehavior],
 
       properties: {
+        currentSite: Object,
+
         prompt: {
           type: String,
-          value: 'Observe your surroundings'
         },
 
         secondsRemaining: {


### PR DESCRIPTION
Previously all the sites used placholder text, 'Observe your surroundings.'
Now the prompt is specified in the map data and routed to the timer.