### PR TITLE
Add missing dev-mode binding for timer-view

### DIFF
--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -33,10 +33,11 @@
         dev-mode="[[devMode]]">
       </map-view>
       <arrival-view name="arrival" route-data="{{routeData}}" location-name="[[currentSite.name]]"></arrival-view>
-      <timer-view 
+      <timer-view
         name="timer"
         prompt="[[currentSite.prompt]]"
-        route-data="{{routeData}}">
+        route-data="{{routeData}}"
+        dev-mode="[[devMode]]">
       </timer-view>
       <checklist-view
         name="checklist"
@@ -69,12 +70,19 @@
                 type: Object,
                 notify: true
               },
-              tailData: Object,
+              tailData: {
+                type: Object,
+                observer: '_tailDataChanged'
+              },
               devMode: {
                 type: Boolean,
                 notify: true,
                 computed: '_checkDebugMode(tailData)'
               }
+          },
+
+          _tailDataChanged: function(data) {
+            console.log('Changed to ', data);
           },
 
           observers: [


### PR DESCRIPTION
It looks like this was lost in the merge somehow, but this fixes the
problem where dev mode wasn't showing the skip button in
timer-view.