### PR TITLE
Fix template declaration

### DIFF
--- a/src/current-site/current-site.html
+++ b/src/current-site/current-site.html
@@ -1,13 +1,13 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 
 <dom-module id="current-site">
-  <indexOfsitelate>
+  <template>
     <style>
       :host {
         display: block;
       }
     </style>
-  </indexOfsitelate>
+  </template>
   <script>
     Polymer({
       is: 'current-site',

--- a/test/current-site_test.html
+++ b/test/current-site_test.html
@@ -3,15 +3,12 @@
 <head>
   <meta name="viewport"
         content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-    <title>current-location tdd-test</title>
+    <title>current-site tests</title>
 
-    <script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-    <script src="../../bower_components/web-component-tester/browser.js"></script>
+    <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+    <script src="../bower_components/web-component-tester/browser.js"></script>
 
-    <!-- Step 1: import the element to test -->
-    <link rel="import"
-          href="../../src/current-site/current-site.html">
-
+    <link rel="import" href="../src/current-site/current-site.html">
 </head>
 
 <body>
@@ -48,7 +45,7 @@
     describe('no latitude nor longitude', function () {
       var element;
 
-      before(function () {
+      beforeEach(function () {
         element = fixture('no-site');
       });
 
@@ -60,7 +57,7 @@
     describe('at first site', function () {
       var element;
 
-      before(function () {
+      beforeEach(function () {
         element = fixture('default');
         element.sites = mapData;
       });
@@ -90,7 +87,7 @@
     describe('out of range of any site', function () {
       var element;
 
-      before(function () {
+      beforeEach(function () {
         element = fixture('default');
         element.sites = mapData;
         element.latitude = 0;

--- a/test/index.html
+++ b/test/index.html
@@ -35,7 +35,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     }
 
     testShadyAndShadow([
-      'current-site/current-site_test.html',
+      'current-site_test.html',
       'checklist-view_test.html',
       'prairie-creek-game_test.html',
       'map-data_test.html',
@@ -46,4 +46,3 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 </body>
 
 </html>
-


### PR DESCRIPTION
It looks like there was an errant find-and-replace that was committed,
but it has been fixed, which I believe fixes #50.

As part of the refactoring while in these files,
current-site_test.html was moved to the top level of the test
directory, bringing it in line with the rest of the test cases. Also,
the `before` methods were changed to `beforeEach`, which didn't change
their behavior (the tests still pass the same) but certainly makes
them more authentic to what was intended.