### PR TITLE
Use 'spirit' instead of 'wudgie' nomenclature

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -9,7 +9,7 @@
     "src/missing-view/missing-view.html",
     "src/timer-view/timer-view.html",
     "src/title-view/title-view.html",
-    "src/wudgie-view/wudgie-view.html"
+    "src/spirit-view/spirit-view.html"
   ],
   "sourceGlobs": [
     "src/**/*",

--- a/src/checklist-view/checklist-view.html
+++ b/src/checklist-view/checklist-view.html
@@ -48,7 +48,7 @@
 
       _next: function() {
         this.currentSite.visited = true;
-        this.nextPage = this._visitedAllSites() ? 'wudgie' : 'map';
+        this.nextPage = this._visitedAllSites() ? 'spirit' : 'map';
         this._goToPage(this.nextPage);
       },
 

--- a/src/map-data/map-data.html
+++ b/src/map-data/map-data.html
@@ -104,10 +104,10 @@
       }
     ];
 
-    const _wudgieData = [
-      'A wudgie found some of our trash and brought it back to you!',
+    const _spiritData = [
+      'A spirit found some of our trash and brought it back to you!',
       'You found a nature spirit!',
-      'You became one with nature and a nature wudgie appeared'
+      'You became one with nature and a nature spirit appeared'
     ];
 
     Polymer({
@@ -120,11 +120,11 @@
             return JSON.parse(JSON.stringify(_default));
           }
         },
-        wudgieData: {
+        spiritData: {
           notify: true,
           type: Object,
           value: function () {
-            return JSON.parse(JSON.stringify(_wudgieData));
+            return JSON.parse(JSON.stringify(_spiritData));
           }
         }
       },

--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -16,7 +16,7 @@
     <app-location route="{{route}}" use-hash-as-path></app-location>
     <app-route route="{{route}}" pattern="/:page" data="{{routeData}}" tail="{{tail}}"></app-route>
     <app-route route="{{tail}}" pattern="/:d" data="{{tailData}}"></app-route>
-    <map-data data="{{mapData}}" wudgie-data="{{wudgieData}}"></map-data>
+    <map-data data="{{mapData}}" spirit-data="{{spiritData}}"></map-data>
     <user-location latitude="{{latitude}}" longitude="{{longitude}}" dev-mode="[[devMode]]"></user-location>
     <current-site latitude="[[latitude]]" longitude="[[longitude]]" sites="[[mapData]]" site="{{currentSite}}"></current-site>
 
@@ -44,7 +44,7 @@
         current-site="[[currentSite]]"
         route-data="{{routeData}}">
       </checklist-view>
-      <wudgie-view name="wudgie" map-data="[[mapData]]" wudgie-data="[[wudgieData]]" route-data="{{routeData}}"></wudgie-view>
+      <spirit-view name="spirit" map-data="[[mapData]]" spirit-data="[[spiritData]]" route-data="{{routeData}}"></spirit-view>
       <collection-view name="collection" route-data="{{routeData}}"></collection-view>
       <missing-view name="missing" route-data="{{routeData}}"></missing-view>
     </iron-pages>
@@ -58,7 +58,7 @@
               mapData: {
                 type: Object
               },
-              wudgieData: {
+              spiritData: {
                 type: Object
               },
               route: {

--- a/src/spirit-view/spirit-view.html
+++ b/src/spirit-view/spirit-view.html
@@ -1,9 +1,8 @@
 <link rel="import" href="../../bower_components/polymer/polymer.html">
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
-
 <link rel="import" href="../view-behavior/view-behavior.html">
 
-<dom-module id="wudgie-view">
+<dom-module id="spirit-view">
   <template>
     <style>
       :host {
@@ -16,37 +15,37 @@
     </style>
     <img src="../../images/placeholder.png"></img>
     <br>
-    [[wudgieText]]
+    [[spiritText]]
     <br>
     <paper-button raised on-tap="_next">Go to collections screen</paper-button>
   </template>
   <script>
     Polymer({
-      is: 'wudgie-view',
+      is: 'spirit-view',
       behaviors: [ViewBehavior],
       properties: {
         mapData: {
           type: Object,
           notify: true
         },
-        wudgieData: {
+        spiritData: {
           type: Object,
           notify: true
         },
-        wudgieText: {
+        spiritText: {
           type: String,
-          computed: '_currentWudgieText(mapData,wudgieData)'
+          computed: '_currentSpiritText(mapData,spiritData)'
         }
       },
 
-      _currentWudgieText: function(mapData,wudgieData) {
-        var wudgieValue = 0;
+      _currentSpiritText: function(mapData,spiritData) {
+        var spiritValue = 0;
         for(var i=0;i<mapData.length;i++) {
           for(var j=0;j<mapData[i].responses.length;j++) {
-            wudgieValue += (mapData[i].responses[j].selected ? mapData[i].responses[j].value : 0);
+            spiritValue += (mapData[i].responses[j].selected ? mapData[i].responses[j].value : 0);
           }
         }
-        return wudgieData[Math.sign(wudgieValue)+1];
+        return spiritData[Math.sign(spiritValue)+1];
       },
 
       _next: function() {

--- a/test/checklist-view_test.html
+++ b/test/checklist-view_test.html
@@ -119,12 +119,12 @@
                         visitSite(1);
                     });
 
-                    it('routes to wudgie view', function () {
-                        expect(element.nextPage).to.equal('wudgie');
+                    it('routes to spirit view', function () {
+                        expect(element.nextPage).to.equal('spirit');
                     });
                 });
 
-                describe('nextPage was wudgie from previous play, then locations are unmarked', function () {
+                describe('nextPage was spirit from previous play, then locations are unmarked', function () {
                     beforeEach(function () {
                         visitSite(0);
                         visitSite(1);

--- a/test/index.html
+++ b/test/index.html
@@ -40,7 +40,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       'prairie-creek-game_test.html',
       'map-data_test.html',
       'map-view_test.html',
-      'wudgie-view_test.html'
+      'spirit-view_test.html'
     ]);
   </script>
 </body>

--- a/test/prairie-creek-game_test.html
+++ b/test/prairie-creek-game_test.html
@@ -27,9 +27,8 @@
     describe('navigate away and back to title view', function () {
       var element;
 
-      beforeEach(function (done) {
+      beforeEach(function () {
         element = fixture('basic');
-        flush(done);
       });
 
       it('resets the map data', function(done) {
@@ -43,7 +42,7 @@
                 done();
             });
         });
-        
+
       });
     });
   </script>

--- a/test/spirit-view_test.html
+++ b/test/spirit-view_test.html
@@ -69,7 +69,7 @@
     describe('spirit-view with sample site data and spirit text', function() {
       var element;
 
-      before(function (done) {
+      beforeEach(function (done) {
         element = fixture('basic');
         resetMapData();
         flush(done);

--- a/test/spirit-view_test.html
+++ b/test/spirit-view_test.html
@@ -1,21 +1,19 @@
 <html>
   <head>
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-    <title>wudgie-view bdd test</title>
+    <title>spirit-view bdd test</title>
 
     <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
     <script src="../bower_components/web-component-tester/browser.js"></script>
 
-    <!-- Step 1: import the element to test -->
-    <link rel="import" href="../src/wudgie-view/wudgie-view.html">
-
+    <link rel="import" href="../src/spirit-view/spirit-view.html">
   </head>
   <body>
 
   <test-fixture id="basic">
     <template>
-      <wudgie-view>
-      </wudgie-view>
+      <spirit-view>
+      </spirit-view>
     </template>
   </test-fixture>
 
@@ -63,12 +61,12 @@
       }];
 
       const textData =  [
-        'A wudgie found some of our trash and brought it back to you!',
+        'A spirit found some of our trash and brought it back to you!',
         'You found a nature spirit!',
-        'You became one with nature and a nature wudgie appeared'
+        'You became one with nature and a nature spirit appeared'
       ];
 
-    describe('wudgie-view with sample site data and wudgie text', function() {
+    describe('spirit-view with sample site data and spirit text', function() {
       var element;
 
       before(function (done) {
@@ -79,15 +77,15 @@
 
       function resetMapData() {
         element.mapData = clone(allSites);
-        element.wudgieData = clone(textData);
+        element.spiritData = clone(textData);
       }
 
       function clone(obj) {
         return JSON.parse(JSON.stringify(obj));
       }
 
-      it('the current wudgie text is the first option', function() {
-        expect(element.wudgieText).to.deep.equal(textData[0]);
+      it('the current spirit text is the first option', function() {
+        expect(element.spiritText).to.deep.equal(textData[0]);
       });
 
     });


### PR DESCRIPTION
In the game design, we're talking about nature spirits, not pukwudgies. This refactoring aligns the code nomenclature with the game nomenclature.