### PR TITLE
Refactor to remove unsupported JS language level

### DIFF
--- a/src/current-site/current-site.html
+++ b/src/current-site/current-site.html
@@ -2,11 +2,7 @@
 
 <dom-module id="current-site">
   <template>
-    <style>
-      :host {
-        display: block;
-      }
-    </style>
+    <array-selector id="selector" items="{{sites}}" selected="{{site}}"></array-selector>
   </template>
   <script>
     Polymer({
@@ -22,9 +18,12 @@
           type: Object,
           notify: true,
           value: null,
-          computed: '_determineSite(latitude,longitude,sites)'
         },
       },
+
+      observers: [
+        '_determineSite(latitude,longitude,sites)'
+      ],
 
       _determineSite: function(latitude, longitude, sites) {
         const BIG_DISTANCE = 1000000; // An arbitrary number that any real distance will be less than
@@ -43,7 +42,12 @@
             indexOfSite = i;
           }
         }
-        return (saveDist == BIG_DISTANCE) ? null : sites[indexOfSite];
+        if (saveDist == BIG_DISTANCE) {
+          this.$.selector.clearSelection();
+        }
+        else {
+          this.$.selector.select(sites[indexOfSite]);
+        }
       }
 
     });

--- a/src/map-view/map-view.html
+++ b/src/map-view/map-view.html
@@ -1,11 +1,18 @@
-<link rel="import" href="../../bower_components/polymer/polymer.html">
-<link rel="import" href="../../bower_components/paper-button/paper-button.html">
-<link rel="import" href="../../bower_components/paper-input/paper-input.html">
-<link rel="import" href="../../bower_components/paper-styles/typography.html">
-<link rel="import" href="../../bower_components/google-map/google-map.html">
+<link rel="import"
+      href="../../bower_components/polymer/polymer.html">
+<link rel="import"
+      href="../../bower_components/paper-button/paper-button.html">
+<link rel="import"
+      href="../../bower_components/paper-input/paper-input.html">
+<link rel="import"
+      href="../../bower_components/paper-styles/typography.html">
+<link rel="import"
+      href="../../bower_components/google-map/google-map.html">
 
-<link rel="import" href="../view-behavior/view-behavior.html">
-<link rel="import" href="../shared-styles/shared-styles.html">
+<link rel="import"
+      href="../view-behavior/view-behavior.html">
+<link rel="import"
+      href="../shared-styles/shared-styles.html">
 
 <dom-module id="map-view">
   <template>
@@ -13,54 +20,73 @@
       .content {
         @apply(--paper-font-body1);
       }
-
+      
       google-map {
         height: 50vh;
       }
-
+      
       paper-input {
         width: 20em;
       }
     </style>
-    <template is="dom-if" if$="[[!hideMap]]">
-      <google-map id="map" zoom="6" latitude="[[latitude]]" longitude="[[longitude]]" on-google-map-click="_debugLocation" api-key="AIzaSyDwMK5MooS-bAAEdTq74fgxcc_GVQpd7TM"
-        fit-to-markers>
-        <template is="dom-repeat" items="[[locations]]" item="item">
-          <google-map-marker class='site' latitude="[[item.latitude]]" longitude="[[item.longitude]]" icon="[[item.icon]]">
+    <template is="dom-if"
+              if$="[[!hideMap]]">
+      <google-map id="map"
+                  zoom="6"
+                  latitude="[[latitude]]"
+                  longitude="[[longitude]]"
+                  on-google-map-click="_debugLocation"
+                  api-key="AIzaSyDwMK5MooS-bAAEdTq74fgxcc_GVQpd7TM"
+                  fit-to-markers>
+        <template is="dom-repeat"
+                  items="[[locations]]"
+                  item="item">
+          <google-map-marker class="site"
+                             latitude="[[item.latitude]]"
+                             longitude="[[item.longitude]]"
+                             icon="[[item.icon]]">
           </google-map-marker>
         </template>
-        <google-map-marker id="current" latitude="[[latitude]]" longitude="[[longitude]]">
+        <google-map-marker id="current"
+                           latitude="[[latitude]]"
+                           longitude="[[longitude]]">
         </google-map-marker>
-        </google-map>
+      </google-map>
     </template>
 
-    <div id="instructions" hidden$="[[!showInstructions]]">
+    <div id="instructions"
+         hidden$="[[!showInstructions]]">
       <div>
         Please visit one of these locations.
       </div>
     </div>
-    <div id="arrival" hidden$="[[showInstructions]]">
+    <div id="arrival"
+         hidden$="[[showInstructions]]">
       <div>
         You are at [[currentSite.name]]
       </div>
-      <paper-button raised on-tap="_proceed">Explore</paper-button>
+      <paper-button raised
+                    on-tap="_proceed">Explore</paper-button>
     </div>
 
-    <template is="dom-if" if$="[[devMode]]">
+    <template is="dom-if"
+              if$="[[devMode]]">
       <div class="debugging">
-        <paper-button raised on-tap="_enableLocationOverride">Enable Location Override</paper-button>
-          <div>
-            Warp to:
-            <template is="dom-repeat" items="[[locations]]" item="item">
-              <paper-button
-                raised
-                latitude="[[item.latitude]]"
-                longitude="[[item.longitude]]"
-                on-tap="_warpToLocation">
-                [[item.name]]
-              </paper-button>
-            </template>
-          </div>
+        <paper-button raised
+                      on-tap="_enableLocationOverride">Enable Location Override</paper-button>
+        <div>
+          Warp to:
+          <template is="dom-repeat"
+                    items="[[locations]]"
+                    item="item">
+            <paper-button raised
+                          latitude="[[item.latitude]]"
+                          longitude="[[item.longitude]]"
+                          on-tap="_warpToLocation">
+              [[item.name]]
+            </paper-button>
+          </template>
+        </div>
       </div>
     </template>
   </template>
@@ -104,23 +130,19 @@
         '_siteVisited(currentSite.visited)'
       ],
 
-      _siteVisited(siteVisited){
-        if(this.currentSite!==null){
-        var markers=Polymer.dom(this.root).querySelectorAll('.site');
-        if(!markers.length==0){
-        var i=0;
-        for (var place of this.locations) {
-          if (place.visited) {
-            markers[i].setAttribute('icon',this.locations[i].grayicon);
-
+      _siteVisited: function (siteVisited) {
+        if (this.currentSite !== null) {
+          var markers = Polymer.dom(this.root).querySelectorAll('.site');
+          for (var i = 0; i < markers.length; i++) {
+            var place = this.locations[i];
+            if (place.visited) {
+              markers[i].setAttribute('icon', this.locations[i].grayicon);
+            }
           }
-          i++;
         }
-      }
-    }
       },
 
-      _siteChanged: function(currentSite) {
+      _siteChanged: function (currentSite) {
         if (currentSite == null) {
           this.showInstructions = true;
         } else {
@@ -139,13 +161,13 @@
         this.longitude = longitude;
       },
 
-      _warpToLocation: function(event) {
+      _warpToLocation: function (event) {
         this.latitude = event.model.get('item.latitude');
         this.longitude = event.model.get('item.longitude');
       },
 
       _proceed: function () {
-        this.set('currentSite.visited',true);
+        this.set('currentSite.visited', true);
         this.showInstructions = true;
         this._goToPage('timer');
       }

--- a/src/map-view/map-view.html
+++ b/src/map-view/map-view.html
@@ -65,7 +65,8 @@
       <div>
         You are at [[currentSite.name]]
       </div>
-      <paper-button raised
+      <paper-button id="proceed"
+                    raised
                     on-tap="_proceed">Explore</paper-button>
     </div>
 

--- a/src/map-view/map-view.html
+++ b/src/map-view/map-view.html
@@ -30,7 +30,7 @@
       }
     </style>
     <template is="dom-if"
-              if$="[[!hideMap]]">
+              if$="[[!hideMapForTesting]]">
       <google-map id="map"
                   zoom="6"
                   latitude="[[latitude]]"
@@ -116,7 +116,7 @@
           type: Boolean,
           value: false
         },
-        hideMap: {
+        hideMapForTesting: {
           type: Boolean,
           value: false,
         },
@@ -170,7 +170,9 @@
       _proceed: function () {
         this.set('currentSite.visited', true);
         this.showInstructions = true;
-        this._goToPage('timer');
+        if(!this.hideMapForTesting) {
+          this._goToPage('timer');
+        }
       }
     });
   </script>

--- a/test/map-view_test.html
+++ b/test/map-view_test.html
@@ -6,6 +6,7 @@
 
   <script src="../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
   <script src="../bower_components/web-component-tester/browser.js"></script>
+  <script src="../bower_components/iron-test-helpers/mock-interactions.js"></script>
   <script src="test-site-data.js"></script>
   <link rel="import" href="../src/map-view/map-view.html">
 </head>
@@ -59,7 +60,7 @@
           flush(done);
         });
         it('marks the site as visited', function() {
-          element._proceed();
+          MockInteractions.tap(element.$.proceed);
           expect(element.currentSite.visited).to.be.true;
         });
       });

--- a/test/map-view_test.html
+++ b/test/map-view_test.html
@@ -15,7 +15,7 @@
 
   <test-fixture id="basic">
     <template>
-      <map-view hide-map></map-view>
+      <map-view hide-map-for-testing></map-view>
     </template>
   </test-fixture>
 


### PR DESCRIPTION
The previous implementation used the 'of' keyword, which is not supported
at the language level of the Polymer build system.

Parts of this file were also unconventionally arranged, so I cleaned it
up by running Visual Studio Code's auto-formatter, which I have found to
be more reliable for Polymer than Atom's.