### PR TITLE
Remove collection-view

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -3,7 +3,6 @@
   "shell": "src/prairie-creek-game/prairie-creek-game.html",
   "fragments": [
     "src/checklist-view/checklist-view.html",
-    "src/collection-view/collection-view.html",
     "src/intro-view/intro-view.html",
     "src/map-view/map-view.html",
     "src/missing-view/missing-view.html",


### PR DESCRIPTION
The view itself was removed a long time ago, but it still seemed to
linger here. No reason for it, so we remove it.