### PR TITLE
Disable gps ping except on map view and on first check

### DIFF
--- a/src/map-view/map-view.html
+++ b/src/map-view/map-view.html
@@ -129,6 +129,10 @@
         '_siteChanged(currentSite)'
       ],
 
+      ready: function() {
+        this.gpsActive = true;
+      },
+
       _determineIcon: function(site) {
         if(site.visited  && !site.icon.includes("-gray")) {
           site.icon=site.icon.replace('.png', '-gray.png');

--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -35,7 +35,7 @@
     <app-route route="{{route}}" pattern="/:page" data="{{routeData}}" tail="{{tail}}"></app-route>
     <app-route route="{{tail}}" pattern="/:d" data="{{tailData}}"></app-route>
     <map-data data="{{mapData}}" spirit-data="{{spiritData}}"></map-data>
-    <user-location latitude="{{latitude}}" longitude="{{longitude}}" dev-mode="[[devMode]]"></user-location>
+    <user-location active="[[gpsActive]]" latitude="{{latitude}}" longitude="{{longitude}}" dev-mode="[[devMode]]"></user-location>
     <current-site latitude="[[latitude]]" longitude="[[longitude]]" sites="[[mapData]]" site="{{currentSite}}"></current-site>
     <iron-localstorage
       name="my-app-storage"
@@ -43,7 +43,7 @@
     </iron-localstorage>
     <drop-menu on-reset="_resetGame"></drop-menu>
 
-    <iron-pages selected="[[routeData.page]]" attr-for-selected="name">
+    <iron-pages id="pages" selected="[[routeData.page]]" attr-for-selected="name" on-iron-select="_onPageChanged">
       <title-view name="title" route-data="{{routeData}}"></title-view>
       <intro-view name="intro" route-data="{{routeData}}"></intro-view>
       <map-view
@@ -53,7 +53,8 @@
         longitude="{{longitude}}"
         current-site="[[currentSite]]"
         route-data="{{routeData}}"
-        dev-mode="[[devMode]]">
+        dev-mode="[[devMode]]"
+        gps-active>
       </map-view>
       <timer-view
         name="timer"
@@ -100,6 +101,10 @@
                 type: Boolean,
                 notify: true,
                 computed: '_checkDebugMode(tailData)'
+              },
+              gpsActive: {
+                type: Boolean,
+                value: false,
               }
           },
 
@@ -132,6 +137,10 @@
           _showPage404: function() {
               this.set('routeData.page', 'missing');
           },
+
+          _onPageChanged: function(e) {
+            this.gpsActive = this.$.pages.selectedItem.hasAttribute('gps-active');
+          },  
 
           _checkDebugMode: function(data) {
             if (data.d) {

--- a/src/user-location/user-location.html
+++ b/src/user-location/user-location.html
@@ -1,11 +1,16 @@
-<link rel="import" href="../../bower_components/polymer/polymer.html">
-<link rel="import" href="../../bower_components/iron-timer/iron-timer.html">
+<link rel="import"
+      href="../../bower_components/polymer/polymer.html">
+<link rel="import"
+      href="../../bower_components/iron-timer/iron-timer.html">
 
 
 <dom-module id="user-location">
   <template>
     <div>
-      <iron-timer id="locationTimer" start-time="[[updateRate]]" current-time="0" on-iron-timer-end="_updateLocation"></iron-timer>
+      <iron-timer id="locationTimer"
+                  start-time="[[updateRate]]"
+                  current-time="0"
+                  on-iron-timer-end="_onTimerEnd"></iron-timer>
     </div>
   </template>
   <script>
@@ -28,6 +33,10 @@
           readOnly: true,
           value: 2
         },
+        active: {
+          type: Boolean,
+          value: false
+        },
         currentSite: {
           type: Object
         },
@@ -41,33 +50,39 @@
         '_devModeCheck(devMode)'
       ],
 
-      ready: function() {
+      ready: function () {
+        // Don't do an active check here: we want to always acquire
+        // our first location, no matter what view we are on.
+        // The timer update function will check the active state for future
+        // updates.
         this.$.locationTimer.start();
+        this._updatePosition();
+      },
+
+      _updatePosition: function (position) {
         var that = this;
-        navigator.geolocation.getCurrentPosition(function(position) {
+        navigator.geolocation.getCurrentPosition(function (position) {
           var coords = position.coords;
           that._setLatitude(coords.latitude);
           that._setLongitude(coords.longitude);
-          console.log('Latitude is ', that.latitude, ' and longitude is ', that.longitude);
+          if (document.location.host.startsWith('localhost')) {
+            console.log('Latitude is ', that.latitude, ' and longitude is ', that.longitude);
+          }
         });
       },
 
-      _devModeCheck: function(devMode){
-        if (devMode == true){
+      _devModeCheck: function (devMode) {
+        if (devMode == true) {
           this.$.locationTimer.pause();
         }
       },
 
-      _updateLocation: function(){
+      _onTimerEnd: function () {
+        if (this.active) {
+          this._updatePosition();
+        }
         this.$.locationTimer.reset();
         this.$.locationTimer.start();
-        var that = this;
-        navigator.geolocation.getCurrentPosition(function(position) {
-          var coords = position.coords;
-          that._setLatitude(coords.latitude);
-          that._setLongitude(coords.longitude);
-          console.log('Latitude is ', that.latitude, ' and longitude is ', that.longitude);
-        });
       }
     });
   </script>


### PR DESCRIPTION
The first check is needed to ensure that we can get into the map
in a good state, and the fact that we do this check is baked into
current-location.

For other checks, I've added a listener to iron-pages that gets
notified after a selection is made. Note that this is separate from
all the plumbing required for PRPL routing: this new on-iron-select
event is fired _after_ the selection process is done, so that we can
use this.$.pages.selectedItem to get the currently-selected element.
We only turn gps pinging on if that element has the gps-active
attribute.

This fixes #69