### PR TITLE
Prevent unwanted gps update off map screen

### DIFF
--- a/src/user-location/user-location.html
+++ b/src/user-location/user-location.html
@@ -44,6 +44,10 @@
           type: Boolean,
           notify: true
         },
+        _first: {
+          type: Boolean,
+          value: true
+        }
       },
 
       observers: [
@@ -62,11 +66,14 @@
       _updatePosition: function (position) {
         var that = this;
         navigator.geolocation.getCurrentPosition(function (position) {
-          var coords = position.coords;
-          that._setLatitude(coords.latitude);
-          that._setLongitude(coords.longitude);
-          if (document.location.host.startsWith('localhost')) {
-            console.log('Latitude is ', that.latitude, ' and longitude is ', that.longitude);
+          if (that.active || that._first) {
+            that._first = false;
+            var coords = position.coords;
+            that._setLatitude(coords.latitude);
+            that._setLongitude(coords.longitude);
+            if (document.location.host.startsWith('localhost')) {
+              console.log('Latitude is ', that.latitude, ' and longitude is ', that.longitude);
+            }
           }
         });
       },


### PR DESCRIPTION
There was a potential timing defect previously:
1. user-location is active, so it sends an async request for gps info
2. user-location becomes inactive
3. asyc call returns, and so position is updated.

This commit fixes that problem, by checking the active status flag
again just before updating latitude and longitude. NB: It has to be
checked before the call, too, to prevent the expensive GPS check.

The _first property was added because we need to grab the GPS position
the first time we load this element, regardless of whether it is
active, so that we have some data to base the rest of our logic upon.

This may fix #85, although it is hard to know for sure since it's a timing problem.
We were unable to reproduce #85 in dev mode, so we'll have to do some
field testing to see if it still comes up.