### PR TITLE
Include enhanced developer mode options through drop-menu

### DIFF
--- a/src/dev-mode-echo/dev-mode-echo.html
+++ b/src/dev-mode-echo/dev-mode-echo.html
@@ -1,0 +1,22 @@
+
+<dom-module id="dev-mode-echo">
+    <template>
+        <style>
+            :host {
+                display: block;
+            }
+        </style>
+        Latitude: [[latitude]] Longitude: [[longitude]]<br/>
+        [[error]]
+    </template>
+    <script>
+        Polymer({
+            is: 'dev-mode-echo',
+            properties: {
+                latitude: Number,
+                longitude: Number,
+                error: String
+            }
+        });
+    </script>
+</dom-module>

--- a/src/drop-menu/drop-menu.html
+++ b/src/drop-menu/drop-menu.html
@@ -1,27 +1,72 @@
-<link rel="import" href="../../bower_components/paper-menu-button/paper-menu-button.html">
-<link rel="import" href="../../bower_components/iron-icons/iron-icons.html">
-<link rel="import" href="../../bower_components/paper-menu/paper-menu.html">
-<link rel="import" href="../../bower_components/paper-item/paper-item.html">
-<link rel="import" href="../../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import"
+      href="../../bower_components/polymer/polymer.html">
+
+<link rel="import"
+      href="../../bower_components/iron-icons/iron-icons.html">
+<link rel="import"
+      href="../../bower_components/paper-checkbox/paper-checkbox.html">
+<link rel="import"
+      href="../../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import"
+      href="../../bower_components/paper-item/paper-item.html">
+<link rel="import"
+      href="../../bower_components/paper-menu/paper-menu.html">
+<link rel="import"
+      href="../../bower_components/paper-menu/paper-submenu.html">
+<link rel="import"
+      href="../../bower_components/paper-menu-button/paper-menu-button.html">
+
+<link rel="import"
+      href="../shared-styles/shared-styles.html">
+
 
 <dom-module id="drop-menu">
   <template>
-    <div>
-    <paper-menu-button horizontal-align="right" close-on-activate="true">
-      <paper-icon-button icon="menu" class="dropdown-trigger"></paper-icon-button>
+    <style include="shared-styles">
+
+    </style>
+    <paper-menu-button id="menu" horizontal-align="right" ignore-select>
+      <paper-icon-button icon="menu"
+                         class="dropdown-trigger"></paper-icon-button>
       <paper-menu class="dropdown-content">
         <paper-item on-tap="_resetGame">Reset</paper-item>
+        <paper-submenu>
+          <paper-item class="menu-trigger">
+            Advanced
+          </paper-item>
+          <paper-menu class="menu-content">
+            <paper-checkbox checked="{{devMode.echo}}">
+              Echo Location
+            </paper-checkbox>
+            <paper-checkbox checked="{{devMode.warp}}">
+              Enable Warp
+            </paper-checkbox>
+            <paper-checkbox checked="{{devMode.override}}">
+              Location Override
+            </paper-checkbox>
+          </paper-menu>
+        </paper-submenu>
       </paper-menu>
     </paper-menu-button>
-  </div>
   </template>
   <script>
     Polymer({
       is: "drop-menu",
+      properties: {
+        devMode: {
+          type: Object,
+          notify: true
+        },
+        disableGps: {
+          type: Boolean,
+          notify: true
+        }
+      },
 
-      _resetGame: function(){
+      _resetGame: function (e) {
+        this.$.menu.opened = false;
         this.fire('reset');
       }
     });
-    </script>
+  </script>
 </dom-module>

--- a/src/map-view/map-view.html
+++ b/src/map-view/map-view.html
@@ -24,6 +24,7 @@
       google-map {
         height: 50vh;
       }
+
       paper-button.proceed {
         display: block;
         width: 30%;
@@ -38,7 +39,14 @@
 
     <div id="locationOn" hidden$="[[!hasLatLong]]">
       <template is="dom-if" if$="[[!hideMapForTesting]]">
-        <google-map id="map" zoom="6" latitude="[[latitude]]" longitude="[[longitude]]" on-google-map-click="_debugLocation" api-key="AIzaSyDwMK5MooS-bAAEdTq74fgxcc_GVQpd7TM"
+        <google-map 
+          id="map"
+          zoom="6"
+          latitude="[[latitude]]"
+          longitude="[[longitude]]"
+          click-events$="[[devMode.override]]"
+          on-google-map-click="_debugLocation"
+          api-key="AIzaSyDwMK5MooS-bAAEdTq74fgxcc_GVQpd7TM"
           fit-to-markers>
           <template is="dom-repeat" items="[[locations]]" item="item">
             <google-map-marker class='siteMarker' latitude="[[item.latitude]]" longitude="[[item.longitude]]" icon="[[_determineIcon(item)]]">
@@ -62,21 +70,18 @@
         Explore
       </paper-button>
 
-      <template is="dom-if" if$="[[devMode]]">
+      <template is="dom-if" if$="[[devMode.warp]]">
         <div class="debugging">
-          <paper-button raised on-tap="_enableLocationOverride">Enable Location Override</paper-button>
-            <div>
-              Warp to:
-              <template is="dom-repeat" items="[[locations]]" item="item">
-                <paper-button
-                  raised
-                  latitude="[[item.latitude]]"
-                  longitude="[[item.longitude]]"
-                  on-tap="_warpToLocation">
-                  [[item.name]]
-                </paper-button>
-              </template>
-            </div>
+          Warp to:
+          <template is="dom-repeat" items="[[locations]]" item="item">
+            <paper-button
+              raised
+              latitude="[[item.latitude]]"
+              longitude="[[item.longitude]]"
+              on-tap="_warpToLocation">
+              [[item.name]]
+            </paper-button>
+          </template>
         </div>
       </template>
     </div>
@@ -106,8 +111,7 @@
           notify: true
         },
         devMode: {
-          type: Boolean,
-          value: false
+          type: Object
         },
 
         hasLatLong: {

--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -20,6 +20,8 @@
 <link rel="import" href="../spirit-view/spirit-view.html">
 <link rel="import" href="../team-view/team-view.html">
 <link rel="import" href="../missing-view/missing-view.html">
+<link rel="import" href="../dev-mode-echo/dev-mode-echo.html">
+
 
 <dom-module id="prairie-creek-game">
   <template>
@@ -34,6 +36,12 @@
         right: 0px;
         z-index: 1;
       }
+
+      dev-mode-echo {
+        position: fixed;
+        top: 0px;
+        left: 0px;
+      }
       
       iron-pages {
         background-color: var(--primary-background-color);
@@ -44,13 +52,27 @@
     </style>
     <app-location route="{{route}}" use-hash-as-path></app-location>
     <app-route route="{{route}}" pattern="/:page" data="{{routeData}}" tail="{{tail}}"></app-route>
-    <app-route route="{{tail}}" pattern="/:d" data="{{tailData}}"></app-route>
     <map-data data="{{mapData}}"></map-data>
-    <user-location active="[[gpsActive]]" latitude="{{latitude}}" longitude="{{longitude}}" dev-mode="[[devMode]]"></user-location>
+    <user-location 
+      active="[[gpsActive]]" 
+      latitude="{{latitude}}"
+      longitude="{{longitude}}"
+      error="{{gpsError}}">
+    </user-location>
     <current-site latitude="[[latitude]]" longitude="[[longitude]]" sites="[[mapData]]" site="{{currentSite}}"></current-site>
     <iron-localstorage name="my-app-storage" value="{{mapData}}">
     </iron-localstorage>
-    <drop-menu on-reset="_resetGame"></drop-menu>
+    <drop-menu 
+      on-reset="_resetGame"
+      dev-mode="{{devMode}}">
+    </drop-menu>
+    <template is="dom-if" if$="[[devMode.echo]]">
+      <dev-mode-echo
+        latitude="[[latitude]]"
+        longitude="[[longitude]]"
+        error="[[gpsError]]">
+      </dev-mode-echo>
+    </template>
 
     <iron-pages id="pages" selected="[[routeData.page]]" attr-for-selected="name" on-iron-select="_onPageChanged">
       <title-view
@@ -120,11 +142,17 @@
                 type: Object,
                 notify: true
               },
-              tailData: Object,
               devMode: {
-                type: Boolean,
+                type: Object,
                 notify: true,
-                computed: '_checkDebugMode(tailData)'
+                value: function() {
+                  return {
+                    echo: false,
+                    warp: false,
+                    override: false
+                  };
+                },
+                observer: '_devModeChanged'
               },
               gpsActive: {
                 type: Boolean,
@@ -166,19 +194,13 @@
             this.gpsActive = this.$.pages.selectedItem.hasAttribute('gps-active');
           },
 
-          _checkDebugMode: function(data) {
-            if (data.d) {
-              console.log('Debug mode enabled');
-              return true;
-            }
-            else {
-              return false;
-            }
-          },
-
           _resetGame: function(){
             this.set('route.path', '/title');
-          }
+          },
+
+          _devModeChanged: function(devMode) {
+            console.log('dev mode: ', devMode);
+          },
       });
   </script>
 </dom-module>

--- a/src/user-location/user-location.html
+++ b/src/user-location/user-location.html
@@ -1,4 +1,5 @@
-<link rel="import" href="../../bower_components/polymer/polymer.html">
+<link rel="import"
+      href="../../bower_components/polymer/polymer.html">
 
 <dom-module id="user-location">
   <script>
@@ -28,8 +29,8 @@
         currentSite: {
           type: Object
         },
-        devMode: {
-          type: Boolean,
+        error: {
+          type: String,
           notify: true
         }
       },
@@ -37,8 +38,8 @@
       ready: function () {
         if ("geolocation" in navigator) {
           var that = this;
-          navigator.geolocation.getCurrentPosition(this._updatePosition(), this._onError);
-          navigator.geolocation.watchPosition(this._onPositionChanged(), this._onError);
+          navigator.geolocation.getCurrentPosition(this._updatePosition(), this._onError());
+          navigator.geolocation.watchPosition(this._onPositionChanged(), this._onError());
         } else {
           alert('Geolocation not available on this device.');
           console.log('Geolocation not available');
@@ -46,15 +47,30 @@
       },
 
       _onError: function (error) {
-        console.log('Geolocation error(' + error.code + '): ' + error.message);
+        var that = this;
+        return function (error) {
+          switch (error.code) {
+            case error.PERMISSION_DENIED:
+              that.error = "Permission denied";
+              break;
+            case error.POSITION_UNAVAILABLE:
+              that.error = "Position unavailable";
+              break;
+            case error.TIMEOUT:
+              that.error = "Timeout";
+              break;
+            case error.UNKNOWN_ERROR:
+              that.error = "Unknown error";
+              break;
+          }
+          console.log('Geolocation error(' + error.code + '): ' + that.error);
+        };
       },
 
       _onPositionChanged: function () {
         var that = this;
         return function (position) {
-          if (that.devMode) {
-            console.log('Ignoring location change; devmode')
-          } else if (!that.active) {
+          if (!that.active) {
             console.log('Ignoring location change; inactive');
           } else {
             that._updatePosition()(position);
@@ -69,6 +85,7 @@
           that._setLatitude(coords.latitude);
           that._setLongitude(coords.longitude);
           console.log('Latitude is ', that.latitude, ' and longitude is ', that.longitude);
+          that.error = '';
         }
       }
     });


### PR DESCRIPTION
"Enhanced developer mode" separates different devmode features for
more fine-grained debugging. Note that the ability to enter dev mode
with the '/d' custom URL has been removed; instead, all of the options
are accessed through the drop menu's new "Advanced" submenu.

The enhanced developer mode options include:

+ echo: Show latitude, longitude, and gps error messages in a text
widget at the top of the screen.

+ warp: Enable or disable location warp (teleporting to sites)

+ override: Enable or disable location override (tap to set location)

Note that with the removal of the timer-based position acquisition, we
no longer needed a way to disable GPS features in developer mode. This
was a solution to an artificial problem, that we were asking for
location on the timer. Now, if you're debugging at a desktop, you can just
set your location with override or sensor manipulation without worrying
about warping back to your home location. The only thing that is lost
is the ability to warp to locations on site in a "sticky" way: sensor
changes will take you out of that site. Realistically, though, that's
not expected gameplay behavior, so I am not worried about that for the
purpose of these developmer mode options.