### PR TITLE
Address lint warnings

### DIFF
--- a/src/dev-mode-echo/dev-mode-echo.html
+++ b/src/dev-mode-echo/dev-mode-echo.html
@@ -6,7 +6,9 @@
                 display: block;
             }
         </style>
-        Latitude: [[latitude]] Longitude: [[longitude]]<br/>
+        Latitude: [[latitude]]
+        Longitude: [[longitude]]
+        <br/>
         [[error]]
     </template>
     <script>

--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -51,7 +51,7 @@
       }
     </style>
     <app-location route="{{route}}" use-hash-as-path></app-location>
-    <app-route route="{{route}}" pattern="/:page" data="{{routeData}}" tail="{{tail}}"></app-route>
+    <app-route route="{{route}}" pattern="/:page" data="{{routeData}}"></app-route>
     <map-data data="{{mapData}}"></map-data>
     <user-location 
       active="[[gpsActive]]" 
@@ -157,7 +157,8 @@
               gpsActive: {
                 type: Boolean,
                 value: false,
-              }
+              },
+              gpsError: String
           },
 
           observers: [

--- a/src/view-behavior/view-behavior.html
+++ b/src/view-behavior/view-behavior.html
@@ -1,4 +1,5 @@
 <script>
+  /** @polymerBehavior ViewBehavior */
   ViewBehavior = {
     properties: {
       routeData: {


### PR DESCRIPTION
I did not know that behaviors had to be marked up with special
metadata so that the linter would read them properly; now that this is
in place, we should not get linter warnings regarding ViewBehavior any
more. I found out about this by looking at
https://github.com/PolymerLabs/polylint/issues/130.

The other changes were pedestrian fixes.