### PR TITLE
Cache spirit images

### DIFF
--- a/src/image-cache/image-cache.html
+++ b/src/image-cache/image-cache.html
@@ -1,0 +1,48 @@
+<link rel="import"
+      href="../../bower_components/polymer/polymer.html">
+
+<dom-module id="image-cache">
+    <script>
+        Polymer({
+            is: 'image-cache',
+            properties: {
+                mapData: {
+                    type: Array,
+                    observer: '_update'
+                },
+                /** The actual cache (DO NOT USE).
+                 * Note that no one ever actually needs to read from this. Simply
+                 * storing the image data seems to do the job within the browser.
+                 * Loading the data without holding a reference to it does not 
+                 * keep it in memory.
+                 */
+                cache: {
+                    type: Array,
+                    notify: true,
+                    value: function () { return []; }
+                },
+                firstRun: {
+                    type: Boolean,
+                    value: true,
+                    readOnly: true
+                }
+            },
+
+            _update: function (data) {
+                if (data && data.length > 0 && this.firstRun) {
+                    this._setFirstRun(false);
+                    console.log('Updating image cache');
+                    var that = this;
+                    data.forEach(function (site) {
+                        ['natural', 'artificial'].forEach(function (type) {
+                            const path = 'images/spirits/' + site.shortname + '-' + type + '.png';
+                            var img = new Image();
+                            img.src = path;
+                            that.cache[site.shortname+type] = img;
+                        });
+                    });
+                } 
+            }
+        });
+    </script>
+</dom-module>

--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -12,6 +12,7 @@
 <link rel="import" href="../user-location/user-location.html">
 <link rel="import" href="../shared-styles/shared-styles.html">
 <link rel="import" href="../drop-menu/drop-menu.html">
+<link rel="import" href="../image-cache/image-cache.html">
 
 <link rel="import" href="../title-view/title-view.html">
 <link rel="import" href="../map-view/map-view.html">
@@ -53,6 +54,7 @@
     <app-location route="{{route}}" use-hash-as-path></app-location>
     <app-route route="{{route}}" pattern="/:page" data="{{routeData}}"></app-route>
     <map-data data="{{mapData}}"></map-data>
+    <image-cache map-data="[[mapData]]"></image-cache>
     <user-location 
       active="[[gpsActive]]" 
       latitude="{{latitude}}"


### PR DESCRIPTION
This loads all the spirit images during app initialization.  Their
paths are stored in the cache, but they're never actually read: simply
holding the persistent reference to them is enough that the browser
keeps the referenced images in memory, so that when other places go
looking for them by path (e.g. spirit-view), there they are.

Fixes #119