### PR TITLE
Revert "Add CNAME for custom domain name handling on github.io"

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-spiritsatprairiecreek.com

--- a/polymer.json
+++ b/polymer.json
@@ -9,7 +9,6 @@
   ],
   "includeDependencies": [
     "manifest.json",
-    "bower_components/webcomponentsjs/webcomponents-lite.min.js",
-    "CNAME"
+    "bower_components/webcomponentsjs/webcomponents-lite.min.js"
   ]
 }


### PR DESCRIPTION
Turns out that if we use the custom domain name, we no longer get served over HTTPS, which means that we cannot use the browser's location service! It will be much easier for us to just forward the domain than to register for and integrate a custom certificate.

Reverts spring2017gamestudio/prairie-creek#133