### PR TITLE
Update configuration for polymer-cli 18.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "devDependencies": {
     "eslint": "^3.12.0",
     "eslint-config-google": "^0.7.1",
-    "eslint-plugin-html": "^1.7.0"
+    "eslint-plugin-html": "^1.7.0",
+    "web-component-tester": "^5.0.1"
   },
   "scripts": {
     "lint": "eslint . --ext js,html; exit 0;",

--- a/polymer.json
+++ b/polymer.json
@@ -2,13 +2,20 @@
   "entrypoint": "index.html",
   "shell": "src/prairie-creek-game/prairie-creek-game.html",
   "fragments": [],
-  "sourceGlobs": [
+  "sources": [
     "src/**/*",
     "images/**/*",
     "bower.json"
   ],
-  "includeDependencies": [
+  "extraDependencies": [
     "manifest.json",
     "bower_components/webcomponentsjs/webcomponents-lite.min.js"
-  ]
+  ],
+  "builds": [{
+    "name": "bundled",
+    "bundle": true,
+    "js": {"minify": true},
+    "css": {"minify": true},
+    "html": {"minify": true}
+  }]
 }


### PR DESCRIPTION
Our build system is configured to pull in the latest version of polymer-cli, but unfortunately there was a change in the `polymer build` output between 17.x and 18.1. This commit addresses those changes, as well as some deprecations to the `polymer.json` format.