### PR TITLE
Fix positioning of spirits on team view

### DIFF
--- a/src/spirit-team/spirit-team.html
+++ b/src/spirit-team/spirit-team.html
@@ -47,9 +47,9 @@
              :host {
                 display: inline-block;
             }
-            
+
             img {
-                position: fixed;
+                position: absolute;
             }
         </style>
         <img src="[[src]]">


### PR DESCRIPTION
Fixed issue #141. Changed the positioning of the spirit team to absolute rather than fixed.