### PR TITLE
Fix firefox defect

### DIFF
--- a/src/current-site/current-site.html
+++ b/src/current-site/current-site.html
@@ -10,7 +10,6 @@
       properties: {
         latitude: Number,
         longitude: Number,
-        range: Number,
         sites: {
           type: Array
         },

--- a/src/prairie-creek-game/prairie-creek-game.html
+++ b/src/prairie-creek-game/prairie-creek-game.html
@@ -59,7 +59,7 @@
       longitude="{{longitude}}"
       error="{{gpsError}}"
       high-accuracy="[[devMode.highAccuracy]]"
-      watch="[[devMode.userLocation]]">
+      watch-gps="[[devMode.userLocation]]">
     </user-location>
     <current-site latitude="[[latitude]]" longitude="[[longitude]]" sites="[[mapData]]" site="{{currentSite}}"></current-site>
     <iron-localstorage

--- a/src/user-location/user-location.html
+++ b/src/user-location/user-location.html
@@ -31,7 +31,7 @@
           value: false,
           observer: '_updateWatchLocation'
         },
-        watch: {
+        watchGps: {
           type: Boolean,
           value: true,
           observer: '_updateWatchLocation'


### PR DESCRIPTION
Turns out the property name "watch" in `current-location` was the culprit. This is fine on Chrome but breaks Firefox. This fixes #145.

Another commit here just removes an unneeded property, part of general cleaning up a la Boy Scout Rule.