### PR TITLE
Configure polymer-cli to build service-worker.js

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -14,6 +14,7 @@
   "builds": [{
     "name": "bundled",
     "bundle": true,
+    "addServiceWorker": true,
     "js": {"minify": true},
     "css": {"minify": true},
     "html": {"minify": true}


### PR DESCRIPTION
In the previous version of polymer-cli, it was the default behavior
to make a service-worker.js file, but with the new release,
the configuration file has to specify it.