### PR TITLE
Update title text to make directions link more clear

### DIFF
--- a/src/title-view/title-view.html
+++ b/src/title-view/title-view.html
@@ -45,8 +45,12 @@
     </container>
     <template is="dom-if" if$="[[!inPlayableRange]]">
       <div class="text">
-        Go to <a href="https://www.google.com/maps/dir/Current+Location/Prairie+Creek+Park,+7801+S+560+E+Rd,+Selma,+IN+47383/@40.2079439,-85.5382922,11z/data=!4m15!1m6!3m5!1s0x881538afad10301f:0x5de41bebe474361b!2sPrairie+Creek+Park!8m2!3d40.1240078!4d-85.2818548!4m7!1m0!1m5!1m1!1s0x881538afad10301f:0x5de41bebe474361b!2m2!1d-85.2818548!2d40.1240078">
-        Prairie Creek Park</a> to play!
+        Please visit Prairie Creek Park to play this game.
+      </div>
+      <div class="text">
+        <a href="https://www.google.com/maps/dir/Current+Location/Prairie+Creek+Park,+7801+S+560+E+Rd,+Selma,+IN+47383/@40.2079439,-85.5382922,11z/data=!4m15!1m6!3m5!1s0x881538afad10301f:0x5de41bebe474361b!2sPrairie+Creek+Park!8m2!3d40.1240078!4d-85.2818548!4m7!1m0!1m5!1m1!1s0x881538afad10301f:0x5de41bebe474361b!2m2!1d-85.2818548!2d40.1240078">
+          Directions to the Park
+        </a>
       </div>
     </template>
     <template is="dom-if" if$="[[inPlayableRange]]">


### PR DESCRIPTION
After I posted on social media, someone contacted me and thought there
was an error, that 'Go to Prairie Creek Park to play' was supposed
to start the game, but it goes to Google Maps. This revision makes
it more obvious.